### PR TITLE
Adding OpenMP based atomics

### DIFF
--- a/atomics/include/desul/atomics/Atomic_Ref.hpp
+++ b/atomics/include/desul/atomics/Atomic_Ref.hpp
@@ -102,7 +102,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_weak(expected,
+    return compare_exchange_weak(expected,
                           desired,
                           order,
                           cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -122,7 +122,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_strong(expected,
+    return compare_exchange_strong(expected,
                             desired,
                             order,
                             cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -194,7 +194,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, true, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_weak(expected,
+    return compare_exchange_weak(expected,
                           desired,
                           order,
                           cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -214,7 +214,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, true, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_strong(expected,
+    return compare_exchange_strong(expected,
                             desired,
                             order,
                             cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -347,7 +347,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, true> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_weak(expected,
+    return compare_exchange_weak(expected,
                           desired,
                           order,
                           cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -367,7 +367,7 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, true> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_strong(expected,
+    return compare_exchange_strong(expected,
                             desired,
                             order,
                             cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -456,7 +456,7 @@ struct basic_atomic_ref<T*, MemoryOrder, MemoryScope, false, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_weak(
       T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_weak(expected,
+    return compare_exchange_weak(expected,
                           desired,
                           order,
                           cmpexch_failure_memory_order<_MemoryOrder>(),
@@ -476,7 +476,7 @@ struct basic_atomic_ref<T*, MemoryOrder, MemoryScope, false, false> {
   template <typename _MemoryOrder = MemoryOrder>
   DESUL_FUNCTION bool compare_exchange_strong(
       T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    compare_exchange_strong(expected,
+    return compare_exchange_strong(expected,
                             desired,
                             order,
                             cmpexch_failure_memory_order<_MemoryOrder>(),

--- a/atomics/include/desul/atomics/Common.hpp
+++ b/atomics/include/desul/atomics/Common.hpp
@@ -141,17 +141,58 @@ using cmpexch_failure_memory_order =
 // Currently that is still considered experimetal on CUDA and sometimes not reliable.
 namespace desul {
 namespace Impl {
-  template<class T>
-  struct numeric_limits_max;
+template<class T>
+struct numeric_limits_max;
 
-  template<>
-  struct numeric_limits_max<uint32_t> {
-    static constexpr uint32_t value = 0xffffffffu;
-  };
-  template<>
-  struct numeric_limits_max<uint64_t> {
-    static constexpr uint64_t value = 0xfffffffflu;
-  };
+template<>
+struct numeric_limits_max<uint32_t> {
+  static constexpr uint32_t value = 0xffffffffu;
+};
+template<>
+struct numeric_limits_max<uint64_t> {
+  static constexpr uint64_t value = 0xfffffffflu;
+};
+
+constexpr bool atomic_always_lock_free(std::size_t size) {
+  return size == 4 || size == 8
+#if defined(DESUL_HAVE_16BYTE_COMPARE_AND_SWAP)
+         || size == 16
+#endif
+      ;
+}
+
+template <std::size_t Size, std::size_t Align>
+DESUL_INLINE_FUNCTION bool atomic_is_lock_free() noexcept {
+  return Size == 4 || Size == 8
+#if defined(DESUL_HAVE_16BYTE_COMPARE_AND_SWAP)
+         || Size == 16
+#endif
+      ;
+}
+
+template<std::size_t N>
+struct atomic_compare_exchange_type;
+
+template<>
+struct atomic_compare_exchange_type<4> {
+  using type = int32_t;
+};
+
+template<>
+struct atomic_compare_exchange_type<8> {
+  using type = int64_t;
+};
+
+template<>
+struct atomic_compare_exchange_type<16> {
+  using type = Dummy16ByteValue;
+};
+
+template<class T>
+struct dont_deduce_this_parameter { using type = T; };
+
+template<class T>
+using dont_deduce_this_parameter_t = typename dont_deduce_this_parameter<T>::type;
 
 }
 }

--- a/atomics/include/desul/atomics/Compare_Exchange.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange.hpp
@@ -18,12 +18,15 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include "desul/atomics/Compare_Exchange_MSVC.hpp"
 #endif
 #ifdef DESUL_HAVE_SERIAL_ATOMICS
-#include "desul/atomics/Compare_Exchange_SERIAL.hpp"
+#include "desul/atomics/Compare_Exchange_Serial.hpp"
 #endif
 #ifdef DESUL_HAVE_CUDA_ATOMICS
 #include "desul/atomics/Compare_Exchange_CUDA.hpp"
 #endif
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include "desul/atomics/Compare_Exchange_HIP.hpp"
+#endif
+#ifdef DESUL_HAVE_OPENMP_ATOMICS
+#include "desul/atomics/Compare_Exchange_OpenMP.hpp"
 #endif
 #endif

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -1,0 +1,101 @@
+/* 
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+#ifndef DESUL_ATOMICS_COMPARE_EXCHANGE_OPENMP_HPP_
+#define DESUL_ATOMICS_COMPARE_EXCHANGE_OPENMP_HPP_
+#include "desul/atomics/Common.hpp"
+#include<cstdio>
+
+#ifdef DESUL_HAVE_OPENMP_ATOMICS
+namespace desul {
+
+#if _OPENMP > 201800
+// atomic_thread_fence for Core Scope
+inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
+  #pragma omp flush acq_rel
+}
+inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
+  #pragma omp flush acq_rel
+}
+inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
+  #pragma omp flush release
+}
+inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
+  #pragma omp flush acquire
+}
+// atomic_thread_fence for Device Scope
+inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
+  #pragma omp flush acq_rel
+}
+inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
+  #pragma omp flush acq_rel
+}
+inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
+  #pragma omp flush release
+}
+inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
+  #pragma omp flush acquire
+}
+#else
+// atomic_thread_fence for Core Scope
+inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
+  #pragma omp flush
+}
+// atomic_thread_fence for Device Scope
+inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
+  #pragma omp flush
+}
+inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
+  #pragma omp flush
+}
+#endif
+
+template <typename T, class MemoryOrder, class MemoryScope>
+T atomic_exchange(
+    T* dest, T value, MemoryOrder, MemoryScope) {
+  T return_val;
+  if(!std::is_same<MemoryOrder,MemoryOrderRelaxed>::value)
+    atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
+  T& x = *dest;
+  #pragma omp atomic capture
+  { return_val = x; x = value; }
+  if(!std::is_same<MemoryOrder,MemoryOrderRelaxed>::value)
+    atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  return return_val;
+}
+
+// OpenMP doesn't have compare exchange, so we use build-ins and rely on testing that this works
+// Note that means we test this in OpenMPTarget offload regions!
+template <typename T, class MemoryOrder, class MemoryScope>
+std::enable_if_t<Impl::atomic_always_lock_free(sizeof(T)),T> atomic_compare_exchange(
+    T* dest, T compare, T value, MemoryOrder, MemoryScope) {
+  using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(T)>::type;
+  cas_t retval = __sync_val_compare_and_swap(
+     reinterpret_cast<volatile cas_t*>(dest), 
+     reinterpret_cast<cas_t&>(compare), 
+     reinterpret_cast<cas_t&>(value));
+  return reinterpret_cast<T&>(retval);
+}
+
+}  // namespace desul
+#endif
+#endif

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -16,8 +16,8 @@ namespace desul {
 #if _OPENMP > 201800
 // atomic_thread_fence for Core Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
-  // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
-  #pragma omp flush acq_rel
+  // There is no explicit seq_cst flush in OpenMP
+  #pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
   #pragma omp flush acq_rel
@@ -30,8 +30,8 @@ inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
 }
 // atomic_thread_fence for Device Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
-  // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
-  #pragma omp flush acq_rel
+  // There is no explicit seq_cst flush in OpenMP
+  #pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
   #pragma omp flush acq_rel

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -55,13 +55,13 @@ struct may_exit_early<Op,
     : std::true_type {};
 
 template <typename Op, typename Scalar1, typename Scalar2>
-constexpr typename std::enable_if<may_exit_early<Op, Scalar1, Scalar2>{}, bool>::type
+constexpr DESUL_FUNCTION typename std::enable_if<may_exit_early<Op, Scalar1, Scalar2>{}, bool>::type
 check_early_exit(Op const&, Scalar1 const& val1, Scalar2 const& val2) {
   return Op::check_early_exit(val1, val2);
 }
 
 template <typename Op, typename Scalar1, typename Scalar2>
-constexpr typename std::enable_if<!may_exit_early<Op, Scalar1, Scalar2>{}, bool>::type
+constexpr DESUL_FUNCTION typename std::enable_if<!may_exit_early<Op, Scalar1, Scalar2>{}, bool>::type
 check_early_exit(Op const&, Scalar1 const&, Scalar2 const&) {
   return false;
 }

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -150,45 +150,6 @@ struct LoadOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2&) { return val1; }
 };
 
-constexpr bool atomic_always_lock_free(std::size_t size) {
-  return size == 4 || size == 8
-#if defined(DESUL_HAVE_16BYTE_COMPARE_AND_SWAP)
-         || size == 16
-#endif
-      ;
-}
-
-template <std::size_t Size, std::size_t Align>
-DESUL_INLINE_FUNCTION bool atomic_is_lock_free() noexcept {
-  return Size == 4 || Size == 8
-#if defined(DESUL_HAVE_16BYTE_COMPARE_AND_SWAP)
-         || Size == 16
-#endif
-      ;
-}
-
-template<std::size_t N>
-struct atomic_compare_exchange_type;
-
-template<>
-struct atomic_compare_exchange_type<4> {
-  using type = int32_t;
-};
-
-template<>
-struct atomic_compare_exchange_type<8> {
-  using type = int64_t;
-};
-
-template<>
-struct atomic_compare_exchange_type<16> {
-  using type = Dummy16ByteValue;
-};
-
-template<class T>
-struct dont_deduce_this_parameter { using type = T; };
-template<class T>
-using dont_deduce_this_parameter_t = typename dont_deduce_this_parameter<T>::type;
 
 template <class Oper, typename T, class MemoryOrder, class MemoryScope,
   // equivalent to:
@@ -695,4 +656,5 @@ DESUL_INLINE_FUNCTION bool atomic_compare_exchange_weak(T* const dest,
 #include <desul/atomics/CUDA.hpp>
 #include <desul/atomics/GCC.hpp>
 #include <desul/atomics/HIP.hpp>
+#include <desul/atomics/OpenMP.hpp>
 #endif

--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -57,16 +57,14 @@ inline void finalize_lock_arrays() {
 }
 template <typename MemoryScope>
 inline bool lock_address(void* ptr, MemoryScope ms) {
-  return 0 == atomic_compare_exchange(host_locks__::get_host_lock_(ptr),
-                                      int32_t(0),
+  return 0 == atomic_exchange(host_locks__::get_host_lock_(ptr),
                                       int32_t(1),
                                       MemoryOrderSeqCst(),
                                       ms);
 }
 template <typename MemoryScope>
 void unlock_address(void* ptr, MemoryScope ms) {
-  (void)atomic_compare_exchange(host_locks__::get_host_lock_(ptr),
-                                int32_t(1),
+  (void)atomic_exchange(host_locks__::get_host_lock_(ptr),
                                 int32_t(0),
                                 MemoryOrderSeqCst(),
                                 ms);

--- a/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
@@ -22,6 +22,9 @@ namespace Impl {
 #ifdef __CUDA_ARCH__
 #define DESUL_IMPL_BALLOT_MASK(m, x) __ballot_sync(m, x)
 #define DESUL_IMPL_ACTIVEMASK __activemask()
+#else
+#define DESUL_IMPL_BALLOT_MASK(m, x) 0
+#define DESUL_IMPL_ACTIVEMASK 0
 #endif
 
 /// \brief This global variable in Host space is the central definition

--- a/atomics/include/desul/atomics/Macros.hpp
+++ b/atomics/include/desul/atomics/Macros.hpp
@@ -11,9 +11,11 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 // Macros
 
-#if defined(__GNUC__) &&                              \
-    (!defined(__CUDA_ARCH__) || !defined(__NVCC__) || \
-     !defined(__HIP_DEVICE_COMPILE) || !defined(__HIP_PLATFORM_HCC__))
+#if defined(__GNUC__) && \
+    (!defined(__CUDA_ARCH__) || !defined(__NVCC__)) && \
+    (!defined(__HIP_DEVICE_COMPILE) || !defined(__HIP_PLATFORM_HCC__)) && \
+    !defined(DESUL_HAVE_OPENMP_ATOMICS) && \
+    !defined(DESUL_HAVE_SERIAL_ATOMICS)
 #define DESUL_HAVE_GCC_ATOMICS
 #endif
 
@@ -43,7 +45,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_FUNCTION
 #endif
 
-#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+#if !defined(DESUL_HAVE_GPU_LIKE_PROGRESS)
 #define DESUL_HAVE_FORWARD_PROGRESS
 #endif
 

--- a/atomics/include/desul/atomics/OpenMP.hpp
+++ b/atomics/include/desul/atomics/OpenMP.hpp
@@ -1,0 +1,15 @@
+/* 
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+#ifndef DESUL_ATOMICS_OPENMP_HPP_
+#define DESUL_ATOMICS_OPENMP_HPP_
+
+#ifdef DESUL_HAVE_OPENMP_ATOMICS
+
+#include<desul/atomics/openmp/OpenMP_40.hpp>
+#endif
+#endif

--- a/atomics/include/desul/atomics/openmp/OpenMP_40.hpp
+++ b/atomics/include/desul/atomics/openmp/OpenMP_40.hpp
@@ -69,8 +69,6 @@ namespace desul {
 #include<desul/atomics/openmp/OpenMP_40_op.inc>
 #undef MEMORY_SCOPE
 #undef MEMORY_ORDER
-#define MEMORY_ORDER MemoryOrderRelaxed
-#undef MEMORY_ORDER
 
 #define MEMORY_ORDER MemoryOrderAcqRel
 // #define MEMORY_SCOPE MemoryScopeNode
@@ -83,8 +81,6 @@ namespace desul {
 #include<desul/atomics/openmp/OpenMP_40_op.inc>
 #undef MEMORY_SCOPE
 #undef MEMORY_ORDER
-#define MEMORY_ORDER MemoryOrderRelaxed
-#undef MEMORY_ORDER
 
 #define MEMORY_ORDER MemoryOrderSeqCst
 // #define MEMORY_SCOPE MemoryScopeNode
@@ -96,8 +92,6 @@ namespace desul {
 #define MEMORY_SCOPE MemoryScopeCore
 #include<desul/atomics/openmp/OpenMP_40_op.inc>
 #undef MEMORY_SCOPE
-#undef MEMORY_ORDER
-#define MEMORY_ORDER MemoryOrderRelaxed
 #undef MEMORY_ORDER
 }  // namespace desul
 #endif

--- a/atomics/include/desul/atomics/openmp/OpenMP_40.hpp
+++ b/atomics/include/desul/atomics/openmp/OpenMP_40.hpp
@@ -1,0 +1,103 @@
+/* 
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_OPENMP40_HPP_
+#define DESUL_ATOMICS_OPENMP40_HPP_
+#include<type_traits>
+
+namespace desul {
+namespace Impl {
+  template<class MEMORY_ORDER_TMP, class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_pre_capture_flush(MEMORY_ORDER_TMP, MEMORY_SCOPE_TMP) {}
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_pre_capture_flush(MemoryOrderAcquire, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderAcquire(), MEMORY_SCOPE_TMP());
+  }
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_pre_capture_flush(MemoryOrderAcqRel, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderAcqRel(), MEMORY_SCOPE_TMP());
+  }
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_pre_capture_flush(MemoryOrderSeqCst, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderSeqCst(), MEMORY_SCOPE_TMP());
+  }
+
+  template<class MEMORY_ORDER_TMP, class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_post_capture_flush(MEMORY_ORDER_TMP, MEMORY_SCOPE_TMP) {}
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_post_capture_flush(MemoryOrderRelease, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderRelease(), MEMORY_SCOPE_TMP());
+  }
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_post_capture_flush(MemoryOrderAcqRel, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderAcqRel(), MEMORY_SCOPE_TMP());
+  }
+  template<class MEMORY_SCOPE_TMP>
+  void openmp_maybe_call_post_capture_flush(MemoryOrderSeqCst, MEMORY_SCOPE_TMP) {
+    atomic_thread_fence(MemoryOrderSeqCst(), MEMORY_SCOPE_TMP());
+  }
+
+  template<class T>
+  struct is_openmp_atomic_type_t {
+    static constexpr bool value = std::is_arithmetic<T>::value;
+  };
+  template<class T>
+  constexpr bool is_openmp_atomic_type_v = is_openmp_atomic_type_t<T>::value;
+}
+}
+
+namespace desul {
+// Can't use a macro approach to get all definitions since the ops include #pragma omp
+// So gonna use multiple inclusion of the same code snippet here.
+
+// Can't do Node level atomics this way with OpenMP Target, but we could 
+// have a define which says whether or not Device level IS node level (e.g. for pure CPU node)
+
+#define MEMORY_ORDER MemoryOrderRelaxed
+// #define MEMORY_SCOPE MemoryScopeNode
+// #include<desul/atomics/openmp/OpenMP_40_op.inc>
+// #undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeDevice
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeCore
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#undef MEMORY_ORDER
+#define MEMORY_ORDER MemoryOrderRelaxed
+#undef MEMORY_ORDER
+
+#define MEMORY_ORDER MemoryOrderAcqRel
+// #define MEMORY_SCOPE MemoryScopeNode
+// #include<desul/atomics/openmp/OpenMP_40_op.inc>
+// #undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeDevice
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeCore
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#undef MEMORY_ORDER
+#define MEMORY_ORDER MemoryOrderRelaxed
+#undef MEMORY_ORDER
+
+#define MEMORY_ORDER MemoryOrderSeqCst
+// #define MEMORY_SCOPE MemoryScopeNode
+// #include<desul/atomics/openmp/OpenMP_40_op.inc>
+// #undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeDevice
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#define MEMORY_SCOPE MemoryScopeCore
+#include<desul/atomics/openmp/OpenMP_40_op.inc>
+#undef MEMORY_SCOPE
+#undef MEMORY_ORDER
+#define MEMORY_ORDER MemoryOrderRelaxed
+#undef MEMORY_ORDER
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/openmp/OpenMP_40_op.inc
+++ b/atomics/include/desul/atomics/openmp/OpenMP_40_op.inc
@@ -1,0 +1,101 @@
+
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_fetch_add(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());
+    #pragma omp atomic capture                                                    
+    { tmp = *dest;  *dest += value; }                                             
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_fetch_sub(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { tmp = *dest;  *dest -= value; }                                             
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_fetch_and(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    #pragma omp atomic capture                                                    
+    { tmp = *dest;  *dest &= value; }                                             
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_fetch_or(   
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { tmp = *dest;  *dest |= value; }                                             
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_fetch_xor(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { tmp = *dest;  *dest ^= value; }                                             
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_add_fetch(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { *dest += value; tmp = *dest; }                                              
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_sub_fetch(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { *dest -= value; tmp = *dest; }                                              
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_and_fetch(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { *dest &= value; tmp = *dest; }                                              
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_or_fetch(   
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { *dest |= value; tmp = *dest; }                                              
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }                                                                               
+  template <typename T>                                                           
+  std::enable_if_t<Impl::is_openmp_atomic_type_v<T>,T> atomic_xor_fetch(  
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       
+    T tmp;                                                                        
+    Impl::openmp_maybe_call_pre_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());    
+    #pragma omp atomic capture                                                    
+    { *dest ^= value; tmp = *dest; }                                              
+    Impl::openmp_maybe_call_post_capture_flush(MEMORY_ORDER(), MEMORY_SCOPE());   
+    return tmp;                                                                   
+  }

--- a/atomics/performance_tests/kokkos_based/PerfTestAtomicsLoc_Scope.inc
+++ b/atomics/performance_tests/kokkos_based/PerfTestAtomicsLoc_Scope.inc
@@ -1,6 +1,8 @@
 #define MEMORY_SCOPE MemoryScopeDevice
 #include "PerfTestAtomicsLoc_Order.inc"
 #undef MEMORY_SCOPE 
+#ifdef DESUL_TEST_SCOPE_NODE
 #define MEMORY_SCOPE MemoryScopeNode
 #include "PerfTestAtomicsLoc_Order.inc"
 #undef MEMORY_SCOPE
+#endif

--- a/atomics/performance_tests/kokkos_based/PerfTestAtomicsNeigh_Scope.inc
+++ b/atomics/performance_tests/kokkos_based/PerfTestAtomicsNeigh_Scope.inc
@@ -1,6 +1,8 @@
 #define MEMORY_SCOPE MemoryScopeDevice
 #include "PerfTestAtomicsNeigh_Order.inc"
 #undef MEMORY_SCOPE 
+#ifdef DESUL_TEST_MEMORY_SCOPE_NODE
 #define MEMORY_SCOPE MemoryScopeNode
 #include "PerfTestAtomicsNeigh_Order.inc"
 #undef MEMORY_SCOPE
+#endif

--- a/atomics/performance_tests/kokkos_based/compound_uint64_t_3_loc.cpp
+++ b/atomics/performance_tests/kokkos_based/compound_uint64_t_3_loc.cpp
@@ -43,6 +43,8 @@
 */
 
 #include "PerfTestAtomics.hpp"
+// TODO: Not supported with OpenMPTarget yet
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 #define MEMORY_SPACE DefaultExecutionSpace::memory_space
 #define EXECUTION_SPACE DefaultExecutionSpace
 #define SCALAR compound_type<uint64_t,3>
@@ -83,4 +85,5 @@
 #define MEMORY_OP atomic_fetch_max_op
 #include "PerfTestAtomicsLoc_Scope.inc"
 #undef MEMORY_OP
+#endif
 

--- a/atomics/performance_tests/kokkos_based/compound_uint64_t_3_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/compound_uint64_t_3_neigh.cpp
@@ -43,6 +43,8 @@
 */
 
 #include "PerfTestAtomics.hpp"
+// TODO: Not Supported with OpenMPTarget yet
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 #define MEMORY_SPACE DefaultExecutionSpace::memory_space
 #define EXECUTION_SPACE DefaultExecutionSpace
 #define SCALAR compound_type<uint64_t,3>
@@ -83,4 +85,4 @@
 #define MEMORY_OP atomic_fetch_max_op
 #include "PerfTestAtomicsNeigh_Scope.inc"
 #undef MEMORY_OP
-
+#endif


### PR DESCRIPTION
First stab at adding OpenMP based atomics. Compiles and seems to work both for CPU and OpenMPTarget (for the latter as long as you don't hit the lock based atomics). Its slower though than the atomic builtins for GCC. Also note: i am using the OLD __sync_compare_and_swap GCC intrinsic for compare exchange. That does produce correct code on host and device it looks like. 

You need to explicitly add DESUL_ENABLE_OPENMP_ATOMICS to your CXX flags though