### PR TITLE
Fix CUDA/HIP warnigns and make lock array functions weak symbols

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -16,41 +16,41 @@ namespace desul {
 // Only include if compiling device code, or the CUDA compiler is not NVCC (i.e. Clang)
 // atomic_thread_fence implementation
 #if defined(__CUDA_ARCH__) || !defined(__NVCC__)
-__device__ void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
+__device__ inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
   __threadfence();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
   __threadfence();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
   __threadfence();
 }
-__device__ void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
+__device__ inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
   __threadfence();
 }
-__device__ void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
+__device__ inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
   __threadfence_block();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
   __threadfence_block();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
   __threadfence_block();
 }
-__device__ void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
+__device__ inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
   __threadfence_block();
 }
 #if (__CUDA_ARCH__>=600) || !defined(__NVCC__)
-__device__ void atomic_thread_fence(MemoryOrderRelease, MemoryScopeNode) {
+__device__ inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeNode) {
   __threadfence_system();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeNode) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeNode) {
   __threadfence_system();
 }
-__device__ void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeNode) {
+__device__ inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeNode) {
   __threadfence_system();
 }
-__device__ void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeNode) {
+__device__ inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeNode) {
   __threadfence_system();
 }
 #endif
@@ -183,7 +183,6 @@ __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_excha
 #if defined(__CUDA_ARCH__) || !defined(__NVCC__)
 namespace desul {
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION 
 __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front
@@ -211,7 +210,6 @@ __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::typ
   return return_val;
 }
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION 
 __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_exchange(
     T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front

--- a/atomics/include/desul/atomics/HIP.hpp
+++ b/atomics/include/desul/atomics/HIP.hpp
@@ -5,8 +5,8 @@ Source: https://github.com/desul/desul
 
 SPDX-License-Identifier: (BSD-3-Clause)
 */
-#ifndef DESUL_ATOMICS_CUDA_HPP_
-#define DESUL_ATOMICS_CUDA_HPP_
+#ifndef DESUL_ATOMICS_HIP_HPP_
+#define DESUL_ATOMICS_HIP_HPP_
 
 #ifdef __HIP_DEVICE_COMPILE__
 namespace desul {
@@ -222,7 +222,7 @@ __device__ inline
 
 template <typename T, typename MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_typename_atomic_integer_type<T>::value, T>::type
+    typename std::enable_if<Impl::is_hip_atomic_integer_type<T>::value, T>::type
     atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicXor(dest, val);
@@ -261,6 +261,77 @@ __device__ inline
     atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_or(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
+
+}
+
+#define DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MEMORY_ORDER, MEMORY_SCOPE)                 \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_add_type<T>::value, T>::type atomic_fetch_add(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::AddOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_sub_type<T>::value, T>::type atomic_fetch_sub(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::SubOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_fetch_and(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::AndOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_fetch_or(   \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::OrOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_fetch_xor(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::XorOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_fetch_nand( \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_fetch_oper(Impl::NandOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_add_type<T>::value, T>::type atomic_add_fetch(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::AddOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_sub_type<T>::value, T>::type atomic_sub_fetch(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::SubOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_and_fetch(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::AndOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_or_fetch(   \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::OrOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_xor_fetch(  \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::XorOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }                                                                               \
+  template <typename T>                                                           \
+  __device__ typename std::enable_if<std::is_integral<T>::value && !Impl::is_hip_atomic_integer_type<T>::value, T>::type atomic_nand_fetch( \
+      T* const dest, T value, MEMORY_ORDER, MEMORY_SCOPE) {                       \
+       return Impl::atomic_oper_fetch(Impl::NandOper<T, const T>(), dest, value, MEMORY_ORDER(), MEMORY_SCOPE()); \
+  }
+namespace desul {
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderRelaxed, MemoryScopeNode)
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderRelaxed, MemoryScopeDevice)
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderRelaxed, MemoryScopeCore)
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderSeqCst, MemoryScopeNode)
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderSeqCst, MemoryScopeDevice)
+DESUL_HIP_GCC_INTEGRAL_OP_ATOMICS_COMPATIBILITY(MemoryOrderSeqCst, MemoryScopeCore)
 }  // namespace desul
 
 #endif

--- a/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
@@ -23,7 +23,7 @@ namespace Impl {
 #define DESUL_IMPL_BALLOT_MASK(m, x) __ballot_sync(m, x)
 #define DESUL_IMPL_ACTIVEMASK __activemask()
 #else
-#define DESUL_IMPL_BALLOT_MASK(m, x) 0
+#define DESUL_IMPL_BALLOT_MASK(m, x) m==0?0:1
 #define DESUL_IMPL_ACTIVEMASK 0
 #endif
 
@@ -32,16 +32,23 @@ namespace Impl {
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
+
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.
 ///
 /// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snapshotted version while also linking against pure Desul
+template<typename /*AlwaysInt*/ = int>
 void init_lock_arrays_cuda();
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        all null pointers, and all array memory has been freed.
 ///
 /// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snappshotted version while also linking against pure Desul
+template<typename T = int>
 void finalize_lock_arrays_cuda();
 
 }  // namespace Impl

--- a/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
@@ -32,7 +32,6 @@ namespace Impl {
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
-
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.
 ///
@@ -47,8 +46,8 @@ void init_lock_arrays_cuda();
 ///
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
-///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+///   snapshotted version while also linking against pure Desul
+template<typename /*AlwaysInt*/ = int>
 void finalize_lock_arrays_cuda();
 
 }  // namespace Impl
@@ -160,7 +159,7 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 
 #endif /* defined( __CUDACC__ ) */
 
-#endif /* defined( KOKKOS_ENABLE_CUDA ) */
+#endif /* defined( DESUL_HAVE_CUDA_ATOMICS ) */
 
 #if defined(__CUDACC_RDC__) || (!defined(__CUDACC__))
 #define DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE()

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -6,8 +6,8 @@ Source: https://github.com/desul/desul
 SPDX-License-Identifier: (BSD-3-Clause)
 */
 
-#ifndef DESUL_ATORMICS_LOCK_ARRAY_HIP_HPP_
-#define DESUL_ATORMICS_LOCK_ARRAY_HIP_HPP_
+#ifndef DESUL_ATOMICS_LOCK_ARRAY_HIP_HPP_
+#define DESUL_ATOMICS_LOCK_ARRAY_HIP_HPP_
 
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
@@ -37,8 +37,8 @@ extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 ///
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
-///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+///   snapshotted version while also linking against pure Desul
+template<typename /*AlwaysInt*/ = int>
 void init_lock_arrays_hip();
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
@@ -46,8 +46,8 @@ void init_lock_arrays_hip();
 ///
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
-///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+///   snapshotted version while also linking against pure Desul
+template<typename /*AlwaysInt*/ = int>
 void finalize_lock_arrays_hip();
 }  // namespace Impl
 }  // namespace desul

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -32,20 +32,22 @@ namespace Impl {
 extern int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE_h;
 extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 
-/**
- * \brief After this call, the g_host_hip_lock_arrays variable has valid,
- * initialized arrays.
- *
- * This call is idempotent.
- */
+/// \brief After this call, the g_host_cuda_lock_arrays variable has
+///        valid, initialized arrays.
+///
+/// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snappshotted version while also linking against pure Desul
+template<typename T = int>
 void init_lock_arrays_hip();
 
-/**
- * \brief After this call, the g_host_hip_lock_arrays variable has all null
- * pointers, and all array memory has been freed.
- *
- * This call is idempotent.
- */
+/// \brief After this call, the g_host_cuda_lock_arrays variable has
+///        all null pointers, and all array memory has been freed.
+///
+/// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snappshotted version while also linking against pure Desul
+template<typename T = int>
 void finalize_lock_arrays_hip();
 }  // namespace Impl
 }  // namespace desul
@@ -146,10 +148,10 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 #define DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                               \
   {                                                                               \
     if (::desul::Impl::lock_array_copied == 0) {                                  \
-      hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE), \
+      (void) hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE), \
                         &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,          \
                         sizeof(int32_t*));                                        \
-      hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE),   \
+      (void) hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE),   \
                         &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE_h,            \
                         sizeof(int32_t*));                                        \
     }                                                                             \

--- a/atomics/src/Lock_Array_CUDA.cpp
+++ b/atomics/src/Lock_Array_CUDA.cpp
@@ -8,6 +8,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Lock_Array.hpp>
 #include <cinttypes>
+#include <string>
+#include <sstream>
 
 #ifdef DESUL_HAVE_CUDA_ATOMICS
 #ifdef __CUDACC_RDC__
@@ -35,21 +37,46 @@ __global__ void init_lock_arrays_cuda_kernel() {
 
 namespace Impl {
 
+
 int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
 int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
+// Putting this into anonymous namespace so we don't have multiple defined symbols
+// When linking in more than one copy of the object file
+namespace {
+
+void check_error_and_throw_cuda(cudaError e, const std::string msg) {
+  if(e != cudaSuccess) {
+    std::ostringstream out;
+    out << "Desul::Error: " << msg << " error(" << cudaGetErrorName(e)
+                  << "): " << cudaGetErrorString(e);
+    throw std::runtime_error(out.str());
+  }
+}
+
+}
+
+// define functions
+template<typename T>
 void init_lock_arrays_cuda() {
   if (CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
   auto error_malloc1 = cudaMalloc(&CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h,
                                  sizeof(int32_t) * (CUDA_SPACE_ATOMIC_MASK + 1));
+  check_error_and_throw_cuda(error_malloc1, "init_lock_arrays_cuda: cudaMalloc device locks");
+
   auto error_malloc2 = cudaMallocHost(&CUDA_SPACE_ATOMIC_LOCKS_NODE_h,
                                  sizeof(int32_t) * (CUDA_SPACE_ATOMIC_MASK + 1));
+  check_error_and_throw_cuda(error_malloc2, "init_lock_arrays_cuda: cudaMalloc host locks");
+
   auto error_sync1 = cudaDeviceSynchronize();
   DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();
+  check_error_and_throw_cuda(error_sync1, "init_lock_arrays_cuda: post mallocs");
   init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
   auto error_sync2 = cudaDeviceSynchronize();
+  check_error_and_throw_cuda(error_sync2, "init_lock_arrays_cuda: post init kernel");
 }
 
+template<typename T>
 void finalize_lock_arrays_cuda() {
   if (CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h == nullptr) return;
   cudaFree(CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h);
@@ -60,6 +87,10 @@ void finalize_lock_arrays_cuda() {
   DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();
 #endif
 }
+
+// Instantiate functions
+template void init_lock_arrays_cuda<int>();
+template void finalize_lock_arrays_cuda<int>();
 
 }  // namespace Impl
 

--- a/atomics/src/Lock_Array_HIP.cpp
+++ b/atomics/src/Lock_Array_HIP.cpp
@@ -8,6 +8,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cinttypes>
 #include <desul/atomics/Lock_Array.hpp>
+#include <string>
+#include <sstream>
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #ifdef DESUL_HIP_RDC
@@ -38,28 +40,59 @@ namespace Impl {
 int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
 int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
-void init_lock_arrays_hip() {
-  if (HIP_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
-  hipMalloc(&HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
-            sizeof(int32_t) * (HIP_SPACE_ATOMIC_MASK + 1));
-  hipHostMalloc(&HIP_SPACE_ATOMIC_LOCKS_NODE_h,
-                sizeof(int32_t) * (HIP_SPACE_ATOMIC_MASK + 1));
-  hipDeviceSynchronize();
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
-  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
-  hipDeviceSynchronize();
+// Putting this into anonymous namespace so we don't have multiple defined symbols
+// When linking in more than one copy of the object file
+namespace {
+
+void check_error_and_throw_hip(hipError_t e, const std::string msg) {
+  if(e != hipSuccess) {
+    std::ostringstream out;
+    out << "Desul::Error: " << msg << " error(" << hipGetErrorName(e)
+                  << "): " << hipGetErrorString(e);
+    throw std::runtime_error(out.str());
+  }
 }
 
+}
+
+template<typename T>
+void init_lock_arrays_hip() {
+  if (HIP_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
+
+  auto error_malloc1 = hipMalloc(&HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
+            sizeof(int32_t) * (HIP_SPACE_ATOMIC_MASK + 1));
+  check_error_and_throw_hip(error_malloc1, "init_lock_arrays_hip: hipMalloc device locks");
+
+  auto error_malloc2 = hipHostMalloc(&HIP_SPACE_ATOMIC_LOCKS_NODE_h,
+                sizeof(int32_t) * (HIP_SPACE_ATOMIC_MASK + 1));
+  check_error_and_throw_hip(error_malloc2, "init_lock_arrays_hip: hipMallocHost host locks");
+
+  auto error_sync1 = hipDeviceSynchronize();
+  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  check_error_and_throw_hip(error_sync1, "init_lock_arrays_hip: post malloc");
+
+  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
+
+  auto error_sync2 = hipDeviceSynchronize();
+  check_error_and_throw_hip(error_sync2, "init_lock_arrays_hip: post init");
+}
+
+template<typename T>
 void finalize_lock_arrays_hip() {
   if (HIP_SPACE_ATOMIC_LOCKS_DEVICE_h == nullptr) return;
-  hipFree(HIP_SPACE_ATOMIC_LOCKS_DEVICE_h);
-  hipHostFree(HIP_SPACE_ATOMIC_LOCKS_NODE_h);
+  auto error_free1 = hipFree(HIP_SPACE_ATOMIC_LOCKS_DEVICE_h);
+  check_error_and_throw_hip(error_free1, "finalize_lock_arrays_hip: free device locks");
+  auto error_free2 = hipHostFree(HIP_SPACE_ATOMIC_LOCKS_NODE_h);
+  check_error_and_throw_hip(error_free2, "finalize_lock_arrays_hip: free host locks");
   HIP_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   HIP_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 #ifdef DESUL_HIP_RDC
   DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
 #endif
 }
+
+template void init_lock_arrays_hip<int>();
+template void finalize_lock_arrays_hip<int>();
 
 }  // namespace Impl
 


### PR DESCRIPTION
To allow linking of external desul and internal kokkos desul I made
the lock array functions weak symbols, so that we only get one of them.