### PR TITLE
added cmake dependent option for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 
 include(cmake/blt_boilerplate.cmake)
 
+cmake_dependent_option(DESUL_ENABLE_TESTS "Build tests" On "ENABLE_TESTS" Off)
+
 # list of backends to add as dependencies
 if(ENABLE_OPENMP)
   list(APPEND DESUL_BACKENDS openmp)

--- a/atomics/performance_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/performance_tests/kokkos_based/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(ENABLE_TESTS)
+if(DESUL_ENABLE_TESTS)
 find_package(Kokkos 3 REQUIRED)
 blt_add_library(NAME kokkos_perf_test_main
                 SOURCES UnitTestMainInit.cpp

--- a/atomics/unit_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/unit_tests/kokkos_based/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(ENABLE_TESTS)
+if(DESUL_ENABLE_TESTS)
 find_package(Kokkos 3 REQUIRED)
 
 # Make sure that Kokkos was built with the requested backends


### PR DESCRIPTION
The ```ENABLE_TESTS``` flag conflicts with RAJA and potentially other libraries due to current desul tests requiring kokkos.