### PR TITLE
Use plain cmake for Kokkos tests

### DIFF
--- a/atomics/performance_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/performance_tests/kokkos_based/CMakeLists.txt
@@ -1,14 +1,13 @@
 if(DESUL_ENABLE_TESTS)
 find_package(Kokkos 3 REQUIRED)
-blt_add_library(NAME kokkos_perf_test_main
-                SOURCES UnitTestMainInit.cpp
-                DEPENDS_ON desul_atomics gtest Kokkos::kokkos ${DESUL_BACKENDS})
+add_library(kokkos_perf_test_main
+            UnitTestMainInit.cpp)
+target_link_libraries(kokkos_perf_test_main desul_atomics gtest Kokkos::kokkos)
 
 foreach(T compound_int32_t_2 compound_uint64_t_3 double float int32_t int64_t uint32_t uint64_t)
-blt_add_executable(NAME ${T}_perf_test
-                   SOURCES ${T}_loc.cpp
-                   DEPENDS_ON desul_atomics kokkos_perf_test_main gtest Kokkos::kokkos ${DESUL_BACKENDS})
-blt_add_test(NAME ${T}_perf_test
-             COMMAND ${T}_perf_test)
+  add_executable(${T}_perf_test
+                 ${T}_loc.cpp)
+  target_link_libraries(${T}_perf_test desul_atomics kokkos_perf_test_main gtest Kokkos::kokkos)
+  add_test(NAME ${T}_perf_test COMMAND ${T}_perf_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
 endif()

--- a/atomics/unit_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/unit_tests/kokkos_based/CMakeLists.txt
@@ -7,14 +7,14 @@ foreach(BACKEND ${DESUL_BACKENDS})
   kokkos_check(DEVICES ${BACKEND})
 endforeach()
 
-blt_add_library(NAME kokkos_unit_test_main
-                SOURCES UnitTestMainInit.cpp
-                DEPENDS_ON desul_atomics gtest Kokkos::kokkos ${DESUL_BACKENDS})
+add_library(kokkos_unit_test_main
+            UnitTestMainInit.cpp)
+target_link_libraries(kokkos_unit_test_main Kokkos::kokkos gtest desul_atomics)
+
 foreach(T complexdouble  complexfloat  double  float  int  longint  longlongint  unsignedint  unsignedlongint)
-blt_add_executable(NAME ${T}_unit_test
-                   SOURCES ${T}.cpp
-                   DEPENDS_ON desul_atomics kokkos_unit_test_main gtest Kokkos::kokkos ${DESUL_BACKENDS})
-blt_add_test(NAME ${T}_unit_test
-             COMMAND ${T}_unit_test)
+  add_executable(${T}_unit_test
+               ${T}.cpp)
+  target_link_libraries(${T}_unit_test desul_atomics kokkos_unit_test_main gtest Kokkos::kokkoscore)
+  add_test(NAME ${T}_unit_test COMMAND ${T}_unit_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
 endif()


### PR DESCRIPTION
We ran into problems that the blt functions did not forward the public interface properties of Kokkos (i.e. some necessary flags were missing). We can either figure out why, or just use plain cmake which seems to do it correct? Since I don't know BLT internals, and have no plan to learn it I just put this out here as an option.