### PR TITLE
CMake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ install(TARGETS desul_atomics
         EXPORT desul_atomics
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
-        RUNTIME DESTINATION lib)
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include)
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/atomics/include/
         DESTINATION include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,14 @@ MACRO(APPEND_GLOB VAR)
 ENDMACRO()
 
 add_subdirectory(atomics)
+
+# install options
+install(TARGETS desul_atomics
+        EXPORT desul_atomics
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/atomics/include/
+        DESTINATION include
+        FILES_MATCHING PATTERN *.hpp)


### PR DESCRIPTION
I'm working on a PR for RAJA which enables desul atomics found [here](https://github.com/LLNL/RAJA/pull/1073), and I noticed that desul has no install targets within its CMake.

