### PR TITLE
Add option to restrict GCC exchange atomics to certain sizes

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
@@ -17,58 +17,74 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #endif
 namespace desul {
 
-#if defined(__clang__) && (__clang_major__>=7) && !defined(__APPLE__)
+namespace Impl {
+template <class T>
+struct atomic_exchange_available_gcc {
+  constexpr static bool value =
+#ifndef DESUL_HAVE_LIBATOMIC
+      (sizeof(T) == 4 ||
+#ifdef DESUL_HAVE_16BYTE_COMPARE_AND_SWAP
+       sizeof(T) == 16 ||
+#endif
+       sizeof(T) == 8) &&
+#endif
+      std::is_trivially_copyable<T>::value;
+};
+}  // namespace Impl
+
+#if defined(__clang__) && (__clang_major__ >= 7) && !defined(__APPLE__)
 // Disable warning for large atomics on clang 7 and up (checked with godbolt)
+// clang-format off
 // error: large atomic operation may incur significant performance penalty [-Werror,-Watomic-alignment]
+// clang-format on
 // https://godbolt.org/z/G7YhqhbG6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Watomic-alignment"
 #endif
-template<class MemoryOrder, class MemoryScope>
+template <class MemoryOrder, class MemoryScope>
 void atomic_thread_fence(MemoryOrder, MemoryScope) {
   __atomic_thread_fence(GCCMemoryOrder<MemoryOrder>::value);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<std::is_trivially_copyable<T>::value, T>
-atomic_exchange(
+std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T> atomic_exchange(
     T* dest, T value, MemoryOrder, MemoryScope) {
   T return_val;
-  __atomic_exchange(
-     dest, &value, &return_val, GCCMemoryOrder<MemoryOrder>::value);
+  __atomic_exchange(dest, &value, &return_val, GCCMemoryOrder<MemoryOrder>::value);
   return return_val;
 }
 
 // Failure mode for atomic_compare_exchange_n cannot be RELEASE nor ACQREL so
 // Those two get handled separatly.
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<std::is_trivially_copyable<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrder, MemoryScope) {
-  (void)__atomic_compare_exchange(
-      dest, &compare, &value, false, GCCMemoryOrder<MemoryOrder>::value, GCCMemoryOrder<MemoryOrder>::value);
+std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrder, MemoryScope) {
+  (void)__atomic_compare_exchange(dest,
+                                  &compare,
+                                  &value,
+                                  false,
+                                  GCCMemoryOrder<MemoryOrder>::value,
+                                  GCCMemoryOrder<MemoryOrder>::value);
   return compare;
 }
 
 template <typename T, class MemoryScope>
-std::enable_if_t<std::is_trivially_copyable<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrderRelease, MemoryScope) {
+std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrderRelease, MemoryScope) {
   (void)__atomic_compare_exchange(
       dest, &compare, &value, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
   return compare;
 }
 
 template <typename T, class MemoryScope>
-std::enable_if_t<std::is_trivially_copyable<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrderAcqRel, MemoryScope) {
+std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrderAcqRel, MemoryScope) {
   (void)__atomic_compare_exchange(
       dest, &compare, &value, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
   return compare;
 }
 
-#if defined(__clang__) && (__clang_major__>=7) && !defined(__APPLE__)
+#if defined(__clang__) && (__clang_major__ >= 7) && !defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif
 }  // namespace desul

--- a/atomics/include/desul/atomics/GCC.hpp
+++ b/atomics/include/desul/atomics/GCC.hpp
@@ -10,7 +10,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_GCC_ATOMICS
 
-#include<type_traits>
+#include <type_traits>
 /*
 Built - in Function : type __atomic_add_fetch(type * ptr, type val, int memorder)
 Built - in Function : type __atomic_sub_fetch(type * ptr, type val, int memorder)
@@ -91,37 +91,41 @@ DESUL_GCC_INTEGRAL_OP_ATOMICS(MemoryOrderSeqCst, MemoryScopeDevice)
 DESUL_GCC_INTEGRAL_OP_ATOMICS(MemoryOrderSeqCst, MemoryScopeCore)
 
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<!std::is_trivially_copyable<T>::value, T>
-atomic_exchange(T* const dest,
-                  Impl::dont_deduce_this_parameter_t<const T> val,
-                  MemoryOrder /*order*/,
-                  MemoryScope scope) {
+std::enable_if_t<!Impl::atomic_exchange_available_gcc<T>::value, T> atomic_exchange(
+    T* const dest,
+    Impl::dont_deduce_this_parameter_t<const T> val,
+    MemoryOrder /*order*/,
+    MemoryScope scope) {
   // Acquire a lock for the address
+  // clang-format off
   while (!Impl::lock_address((void*)dest, scope)) {}
+  // clang-format on
 
-  atomic_thread_fence(MemoryOrderAcquire(),scope);
+  atomic_thread_fence(MemoryOrderAcquire(), scope);
   T return_val = *dest;
   *dest = val;
-  atomic_thread_fence(MemoryOrderRelease(),scope);
+  atomic_thread_fence(MemoryOrderRelease(), scope);
   Impl::unlock_address((void*)dest, scope);
   return return_val;
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<!std::is_trivially_copyable<T>::value, T>
+std::enable_if_t<!Impl::atomic_exchange_available_gcc<T>::value, T>
 atomic_compare_exchange(T* const dest,
-                  Impl::dont_deduce_this_parameter_t<const T> compare,
-                  Impl::dont_deduce_this_parameter_t<const T> val,
-                  MemoryOrder /*order*/,
-                  MemoryScope scope) {
+                        Impl::dont_deduce_this_parameter_t<const T> compare,
+                        Impl::dont_deduce_this_parameter_t<const T> val,
+                        MemoryOrder /*order*/,
+                        MemoryScope scope) {
   // Acquire a lock for the address
+  // clang-format off
   while (!Impl::lock_address((void*)dest, scope)) {}
+  // clang-format on
 
-  atomic_thread_fence(MemoryOrderAcquire(),scope);
+  atomic_thread_fence(MemoryOrderAcquire(), scope);
   T return_val = *dest;
-  if(return_val == compare) {
+  if (return_val == compare) {
     *dest = val;
-    atomic_thread_fence(MemoryOrderRelease(),scope);
+    atomic_thread_fence(MemoryOrderRelease(), scope);
   }
   Impl::unlock_address((void*)dest, scope);
   return return_val;


### PR DESCRIPTION
This eliminates the need for libatomic.
Apologies for the diff, source file had not been formatted properly before.

Co-Authored-By: Christian Trott <crtrott@sandia.gov>