### PR TITLE
Fix bug in lock-based functions with HIP

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
@@ -179,8 +179,8 @@ DESUL_INLINE_FUNCTION __device__
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {
@@ -208,8 +208,8 @@ DESUL_INLINE_FUNCTION __device__
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -246,8 +246,8 @@ atomic_fetch_oper(const Oper& op,
   T return_val;
   int done = 0;
 #ifdef __HIPCC__
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {
@@ -313,8 +313,8 @@ atomic_oper_fetch(const Oper& op,
   T return_val;
   int done = 0;
 #ifdef __HIPCC__
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {


### PR DESCRIPTION
`__ballot` returns an `unsigned long long int` in HIP
and not an `unsigned int` like in CUDA.

Co-Authored-By: Bruno Turcksin <bruno.turcksin@gmail.com>