### PR TITLE
Rename `atomic_wrapping_fetch_{inc,dec}` to `atomic_fetch_<TBD>_{inc,dec}`

### DIFF
--- a/atomics/include/desul/atomics/CUDA.hpp
+++ b/atomics/include/desul/atomics/CUDA.hpp
@@ -97,7 +97,7 @@ atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeCore) {
 }
 
 // Wrapping Atomic Inc
-__device__ inline unsigned int atomic_wrapping_fetch_inc(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrderRelaxed,
                                                 MemoryScopeDevice) {
@@ -105,7 +105,7 @@ __device__ inline unsigned int atomic_wrapping_fetch_inc(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_wrapping_fetch_inc(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrder,
                                                 MemoryScopeDevice) {
@@ -116,15 +116,15 @@ __device__ inline unsigned int atomic_wrapping_fetch_inc(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_wrapping_fetch_inc(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrder,
                                                 MemoryScopeCore) {
-  return atomic_wrapping_fetch_inc(dest, val, MemoryOrder(), MemoryScopeDevice());
+  return atomic_fetch_wrapping_inc(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Wrapping Atomic Dec
-__device__ inline unsigned int atomic_wrapping_fetch_dec(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrderRelaxed,
                                                 MemoryScopeDevice) {
@@ -132,7 +132,7 @@ __device__ inline unsigned int atomic_wrapping_fetch_dec(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_wrapping_fetch_dec(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrder,
                                                 MemoryScopeDevice) {
@@ -143,11 +143,11 @@ __device__ inline unsigned int atomic_wrapping_fetch_dec(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_wrapping_fetch_dec(unsigned int* dest,
+__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
                                                 unsigned int val,
                                                 MemoryOrder,
                                                 MemoryScopeCore) {
-  return atomic_wrapping_fetch_dec(dest, val, MemoryOrder(), MemoryScopeDevice());
+  return atomic_fetch_wrapping_dec(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic Inc
@@ -360,8 +360,8 @@ namespace desul {
   }
   DESUL_IMPL_CUDA_HOST_ATOMIC_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_WRAPPING_FETCH_INC(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_wrapping_fetch_inc(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
+  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_INC(TYPE,ORDER,SCOPE) \
+    inline TYPE atomic_fetch_wrapping_inc(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
     using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
     cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
     cas_t assume = oldval; \
@@ -372,7 +372,7 @@ namespace desul {
     } while (assume != oldval); \
     return reinterpret_cast<TYPE&>(oldval); \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_WRAPPING_FETCH_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
+  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
 
   #define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(TYPE,ORDER,SCOPE) \
     inline void atomic_dec(TYPE* const dest, ORDER order, SCOPE scope) { \
@@ -380,8 +380,8 @@ namespace desul {
   }
   DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(unsigned,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_WRAPPING_FETCH_DEC(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_wrapping_fetch_dec(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
+  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_DEC(TYPE,ORDER,SCOPE) \
+    inline TYPE atomic_fetch_wrapping_dec(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
     using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
     cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
     cas_t assume = oldval; \
@@ -392,7 +392,7 @@ namespace desul {
     } while (assume != oldval); \
     return reinterpret_cast<TYPE&>(oldval); \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_WRAPPING_FETCH_DEC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
+  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_DEC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
 
 #endif // DESUL_HAVE_CUDA_ATOMICS_ASM
 

--- a/atomics/include/desul/atomics/CUDA.hpp
+++ b/atomics/include/desul/atomics/CUDA.hpp
@@ -96,19 +96,19 @@ atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_sub(dest,val,MemoryOrder(),MemoryScopeDevice());
 }
 
-// Wrapping Atomic Inc
-__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrderRelaxed,
-                                                MemoryScopeDevice) {
+// Wrap around atomic add
+__device__ inline unsigned int atomic_fetch_inc_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrderRelaxed,
+                                                    MemoryScopeDevice) {
   return atomicInc(dest, val);
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrder,
-                                                MemoryScopeDevice) {
+__device__ inline unsigned int atomic_fetch_inc_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrder,
+                                                    MemoryScopeDevice) {
   __threadfence();
   unsigned int return_val = atomicInc(dest, val);
   __threadfence();
@@ -116,26 +116,26 @@ __device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_fetch_wrapping_inc(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrder,
-                                                MemoryScopeCore) {
-  return atomic_fetch_wrapping_inc(dest, val, MemoryOrder(), MemoryScopeDevice());
+__device__ inline unsigned int atomic_fetch_inc_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrder,
+                                                    MemoryScopeCore) {
+  return atomic_fetch_inc_mod(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
-// Wrapping Atomic Dec
-__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrderRelaxed,
-                                                MemoryScopeDevice) {
+// Wrap around atomic sub
+__device__ inline unsigned int atomic_fetch_dec_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrderRelaxed,
+                                                    MemoryScopeDevice) {
   return atomicDec(dest, val);
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrder,
-                                                MemoryScopeDevice) {
+__device__ inline unsigned int atomic_fetch_dec_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrder,
+                                                    MemoryScopeDevice) {
   __threadfence();
   unsigned int return_val = atomicDec(dest, val);
   __threadfence();
@@ -143,11 +143,11 @@ __device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
 }
 
 template <typename MemoryOrder>
-__device__ inline unsigned int atomic_fetch_wrapping_dec(unsigned int* dest,
-                                                unsigned int val,
-                                                MemoryOrder,
-                                                MemoryScopeCore) {
-  return atomic_fetch_wrapping_dec(dest, val, MemoryOrder(), MemoryScopeDevice());
+__device__ inline unsigned int atomic_fetch_dec_mod(unsigned int* dest,
+                                                    unsigned int val,
+                                                    MemoryOrder,
+                                                    MemoryScopeCore) {
+  return atomic_fetch_dec_mod(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic Inc
@@ -360,8 +360,8 @@ namespace desul {
   }
   DESUL_IMPL_CUDA_HOST_ATOMIC_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_INC(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_wrapping_inc(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
+  #define DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(TYPE,ORDER,SCOPE) \
+    inline TYPE atomic_fetch_inc_mod(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
     using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
     cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
     cas_t assume = oldval; \
@@ -372,7 +372,7 @@ namespace desul {
     } while (assume != oldval); \
     return reinterpret_cast<TYPE&>(oldval); \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
+  DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
 
   #define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(TYPE,ORDER,SCOPE) \
     inline void atomic_dec(TYPE* const dest, ORDER order, SCOPE scope) { \
@@ -380,8 +380,8 @@ namespace desul {
   }
   DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(unsigned,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_DEC(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_wrapping_dec(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
+  #define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(TYPE,ORDER,SCOPE) \
+    inline TYPE atomic_fetch_dec_mod(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
     using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
     cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
     cas_t assume = oldval; \
@@ -392,7 +392,7 @@ namespace desul {
     } while (assume != oldval); \
     return reinterpret_cast<TYPE&>(oldval); \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_WRAPPING_DEC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
+  DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
 
 #endif // DESUL_HAVE_CUDA_ATOMICS_ASM
 

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -144,13 +144,13 @@ struct RShiftOper {
 };
 
 template <class Scalar1, class Scalar2>
-struct WrappingIncOper {
+struct IncModOper {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return ((val1 >= val2) ? Scalar1(0) : val1 + Scalar1(1)); }
 };
 
 template <class Scalar1, class Scalar2>
-struct WrappingDecOper {
+struct DecModOper {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return (((val1 == Scalar1(0)) | (val1 > val2)) ? val2 : (val1 - Scalar1(1))); }
 };
@@ -633,12 +633,12 @@ DESUL_INLINE_FUNCTION T atomic_fetch_inc(T* const dest,
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T atomic_fetch_wrapping_inc(T* const dest,
-                                         T val,
-                                         MemoryOrder order,
-                                         MemoryScope scope) {
-  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_wrapping_inc.");
-  return Impl::atomic_fetch_oper(Impl::WrappingIncOper<T, const T>(), dest, val, order, scope);
+DESUL_INLINE_FUNCTION T atomic_fetch_inc_mod(T* const dest,
+                                             T val,
+                                             MemoryOrder order,
+                                             MemoryScope scope) {
+  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_inc_mod.");
+  return Impl::atomic_fetch_oper(Impl::IncModOper<T, const T>(), dest, val, order, scope);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
@@ -649,12 +649,12 @@ DESUL_INLINE_FUNCTION T atomic_fetch_dec(T* const dest,
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T atomic_fetch_wrapping_dec(T* const dest,
-                                         T val,
-                                         MemoryOrder order,
-                                         MemoryScope scope) {
-  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_wrapping_dec.");
-  return Impl::atomic_fetch_oper(Impl::WrappingDecOper<T, const T>(), dest, val, order, scope);
+DESUL_INLINE_FUNCTION T atomic_fetch_dec_mod(T* const dest,
+                                             T val,
+                                             MemoryOrder order,
+                                             MemoryScope scope) {
+  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_dec_mod.");
+  return Impl::atomic_fetch_oper(Impl::DecModOper<T, const T>(), dest, val, order, scope);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -633,11 +633,11 @@ DESUL_INLINE_FUNCTION T atomic_fetch_inc(T* const dest,
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T atomic_wrapping_fetch_inc(T* const dest,
+DESUL_INLINE_FUNCTION T atomic_fetch_wrapping_inc(T* const dest,
                                          T val,
                                          MemoryOrder order,
                                          MemoryScope scope) {
-  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_wrapping_fetch_inc.");
+  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_wrapping_inc.");
   return Impl::atomic_fetch_oper(Impl::WrappingIncOper<T, const T>(), dest, val, order, scope);
 }
 
@@ -649,11 +649,11 @@ DESUL_INLINE_FUNCTION T atomic_fetch_dec(T* const dest,
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T atomic_wrapping_fetch_dec(T* const dest,
+DESUL_INLINE_FUNCTION T atomic_fetch_wrapping_dec(T* const dest,
                                          T val,
                                          MemoryOrder order,
                                          MemoryScope scope) {
-  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_wrapping_fetch_dec.");
+  static_assert(std::is_unsigned<T>::value, "Signed types not supported by atomic_fetch_wrapping_dec.");
   return Impl::atomic_fetch_oper(Impl::WrappingDecOper<T, const T>(), dest, val, order, scope);
 }
 

--- a/atomics/include/desul/atomics/HIP.hpp
+++ b/atomics/include/desul/atomics/HIP.hpp
@@ -58,6 +58,9 @@ inline __device__ unsigned long long atomic_fetch_inc(unsigned long long* ptr,  
 inline __device__                int atomic_fetch_dec(               int* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicSub(ptr, 1   ); }
 inline __device__       unsigned int atomic_fetch_dec(      unsigned int* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicSub(ptr, 1u  ); }
 inline __device__ unsigned long long atomic_fetch_dec(unsigned long long* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicAdd(ptr, -1  ); }
+
+inline __device__ unsigned int atomic_fetch_wrapping_inc(   unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicInc(ptr, val); }
+inline __device__ unsigned int atomic_fetch_wrapping_dec(   unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicDec(ptr, val); }
 // clang-format on
 
 #define DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(OP, TYPE)                         \
@@ -99,52 +102,13 @@ DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(sub)
 DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(inc)
 DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(dec)
 
+DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(wrapping_inc, unsigned int)
+DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(wrapping_dec, unsigned int)
+
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_FLOATING_POINT
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP
 
-// clang-format off
-inline __device__ unsigned int atomic_wrapping_fetch_inc(unsigned int* ptr, unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicInc(ptr, val); }
-inline __device__ unsigned int atomic_wrapping_fetch_dec(unsigned int* ptr, unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicDec(ptr, val); }
-// clang-format on
-
-template <typename MemoryOrder>
-inline __device__ unsigned int atomic_wrapping_fetch_inc(unsigned int* ptr,
-                                                         unsigned int val,
-                                                         MemoryOrder,
-                                                         MemoryScopeDevice) {
-  __threadfence();
-  unsigned int return_val = atomicInc(ptr, val);
-  __threadfence();
-  return return_val;
-}
-
-template <typename MemoryOrder>
-inline __device__ unsigned int atomic_wrapping_fetch_inc(unsigned int* ptr,
-                                                         unsigned int val,
-                                                         MemoryOrder,
-                                                         MemoryScopeCore) {
-  return atomic_wrapping_fetch_inc(ptr, val, MemoryOrder(), MemoryScopeDevice());
-}
-
-template <typename MemoryOrder>
-inline __device__ unsigned int atomic_wrapping_fetch_dec(unsigned int* ptr,
-                                                         unsigned int val,
-                                                         MemoryOrder,
-                                                         MemoryScopeDevice) {
-  __threadfence();
-  unsigned int return_val = atomicDec(ptr, val);
-  __threadfence();
-  return return_val;
-}
-
-template <typename MemoryOrder>
-inline __device__ unsigned int atomic_wrapping_fetch_dec(unsigned int* ptr,
-                                                         unsigned int val,
-                                                         MemoryOrder,
-                                                         MemoryScopeCore) {
-  return atomic_wrapping_fetch_dec(ptr, val, MemoryOrder(), MemoryScopeDevice());
-}
 
 // 2/ host-side fallback implementation for atomic functions not provided by GCC
 
@@ -178,6 +142,9 @@ DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_INTEGRAL(max, Max)
 DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT(add, Add)
 DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT(sub, Sub)
 
+DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(wrapping_inc, WrappingIncOper, unsigned int)
+DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(wrapping_dec, WrappingDecOper, unsigned int)
+
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_INTEGRAL
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN
@@ -210,57 +177,6 @@ DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_INCREMENT_DECREMENT(unsigned long long)
 
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_INCREMENT_DECREMENT
 
-template <class MemoryOrder>
-inline __host__ unsigned int atomic_wrapping_fetch_inc(unsigned int* ptr,
-                                                       unsigned int val,
-                                                       MemoryOrder order,
-                                                       MemoryScopeDevice scope) {
-  return Impl::atomic_fetch_oper(
-      Impl::WrappingIncOper<unsigned int, const unsigned int>(),
-      ptr,
-      val,
-      order,
-      scope);
-}
-
-template <class MemoryOrder>
-inline __host__ unsigned int atomic_wrapping_fetch_inc(unsigned int* ptr,
-                                                       unsigned int val,
-                                                       MemoryOrder order,
-                                                       MemoryScopeCore scope) {
-  return Impl::atomic_fetch_oper(
-      Impl::WrappingIncOper<unsigned int, const unsigned int>(),
-      ptr,
-      val,
-      order,
-      scope);
-}
-
-template <class MemoryOrder>
-inline __host__ unsigned int atomic_wrapping_fetch_dec(unsigned int* ptr,
-                                                       unsigned int val,
-                                                       MemoryOrder order,
-                                                       MemoryScopeDevice scope) {
-  return Impl::atomic_fetch_oper(
-      Impl::WrappingDecOper<unsigned int, const unsigned int>(),
-      ptr,
-      val,
-      order,
-      scope);
-}
-
-template <class MemoryOrder>
-inline __host__ unsigned int atomic_wrapping_fetch_dec(unsigned int* ptr,
-                                                       unsigned int val,
-                                                       MemoryOrder order,
-                                                       MemoryScopeCore scope) {
-  return Impl::atomic_fetch_oper(
-      Impl::WrappingDecOper<unsigned int, const unsigned int>(),
-      ptr,
-      val,
-      order,
-      scope);
-}
 
 // 3/ device-side fallback implementation for atomic functions defined in GCC overload
 // set

--- a/atomics/include/desul/atomics/HIP.hpp
+++ b/atomics/include/desul/atomics/HIP.hpp
@@ -59,8 +59,8 @@ inline __device__                int atomic_fetch_dec(               int* ptr,  
 inline __device__       unsigned int atomic_fetch_dec(      unsigned int* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicSub(ptr, 1u  ); }
 inline __device__ unsigned long long atomic_fetch_dec(unsigned long long* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicAdd(ptr, -1  ); }
 
-inline __device__ unsigned int atomic_fetch_wrapping_inc(   unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicInc(ptr, val); }
-inline __device__ unsigned int atomic_fetch_wrapping_dec(   unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicDec(ptr, val); }
+inline __device__       unsigned int atomic_fetch_inc_mod(  unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicInc(ptr, val); }
+inline __device__       unsigned int atomic_fetch_dec_mod(  unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicDec(ptr, val); }
 // clang-format on
 
 #define DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(OP, TYPE)                         \
@@ -102,8 +102,8 @@ DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(sub)
 DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(inc)
 DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL(dec)
 
-DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(wrapping_inc, unsigned int)
-DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(wrapping_dec, unsigned int)
+DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(inc_mod, unsigned int)
+DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(dec_mod, unsigned int)
 
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_FLOATING_POINT
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL
@@ -142,8 +142,8 @@ DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_INTEGRAL(max, Max)
 DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT(add, Add)
 DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT(sub, Sub)
 
-DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(wrapping_inc, WrappingIncOper, unsigned int)
-DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(wrapping_dec, WrappingDecOper, unsigned int)
+DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(inc_mod, IncModOper, unsigned int)
+DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(dec_mod, DecModOper, unsigned int)
 
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_FLOATING_POINT
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN_INTEGRAL

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc
@@ -89,7 +89,7 @@ inline __device__ ctype atomic_fetch_inc(ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMO
   asm volatile("atom.inc" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
 } \
-inline __device__ ctype atomic_fetch_wrapping_inc(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+inline __device__ ctype atomic_fetch_inc_mod(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
   ctype result = 0; \
   asm volatile("atom.inc" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
@@ -102,7 +102,7 @@ inline __device__ ctype atomic_fetch_dec(ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMO
   asm volatile("atom.dec" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
 } \
-inline __device__ ctype atomic_fetch_wrapping_dec(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+inline __device__ ctype atomic_fetch_dec_mod(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
   ctype result = 0; \
   asm volatile("atom.dec" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc
@@ -89,7 +89,7 @@ inline __device__ ctype atomic_fetch_inc(ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMO
   asm volatile("atom.inc" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
 } \
-inline __device__ ctype atomic_wrapping_fetch_inc(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+inline __device__ ctype atomic_fetch_wrapping_inc(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
   ctype result = 0; \
   asm volatile("atom.inc" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
@@ -102,7 +102,7 @@ inline __device__ ctype atomic_fetch_dec(ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMO
   asm volatile("atom.dec" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \
 } \
-inline __device__ ctype atomic_wrapping_fetch_dec(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+inline __device__ ctype atomic_fetch_wrapping_dec(ctype* dest, ctype limit, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
   ctype result = 0; \
   asm volatile("atom.dec" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM asm_ctype " %0,[%1],%2;" : reg_ret_ctype(result) : "l"(dest),reg_ctype(limit) : "memory"); \
   return result; \

--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -453,11 +453,11 @@ bool IncAtomicTest(T i0) {
 }
 
 //---------------------------------------------------
-//-------------atomic_wrapping_increment-------------
+//-------------atomic_inc_mod------------------------
 //---------------------------------------------------
 
 template <class T, class DEVICE_TYPE>
-struct WrappingIncFunctor {
+struct IncModFunctor {
   typedef DEVICE_TYPE execution_space;
   typedef Kokkos::View<T, execution_space> type;
 
@@ -471,11 +471,11 @@ struct WrappingIncFunctor {
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 
-  WrappingIncFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
+  IncModFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
 };
 
 template <class T, class execution_space>
-T WrappingIncAtomic(T i0, T i1) {
+T IncModAtomic(T i0, T i1) {
   struct InitFunctor<T, execution_space> f_init(i0);
   typename InitFunctor<T, execution_space>::type data("Data");
   typename InitFunctor<T, execution_space>::h_type h_data("HData");
@@ -484,7 +484,7 @@ T WrappingIncAtomic(T i0, T i1) {
   Kokkos::parallel_for(1, f_init);
   execution_space().fence();
 
-  struct WrappingIncFunctor<T, execution_space> f(i0, i1);
+  struct IncModFunctor<T, execution_space> f(i0, i1);
 
   f.data = data;
   Kokkos::parallel_for(1, f);
@@ -497,7 +497,7 @@ T WrappingIncAtomic(T i0, T i1) {
 }
 
 template <class T>
-T WrappingIncAtomicCheck(T i0, T i1) {
+T IncModAtomicCheck(T i0, T i1) {
   T* data = new T[1];
   data[0] = 0;
 
@@ -511,16 +511,16 @@ T WrappingIncAtomicCheck(T i0, T i1) {
 }
 
 template <class T, class DeviceType>
-bool WrappingIncAtomicTest(T i0, T i1) {
-  T res = WrappingIncAtomic<T, DeviceType>(i0, i1);
-  T resSerial = WrappingIncAtomicCheck<T>(i0, i1);
+bool IncModAtomicTest(T i0, T i1) {
+  T res = IncModAtomic<T, DeviceType>(i0, i1);
+  T resSerial = IncModAtomicCheck<T>(i0, i1);
 
   bool passed = true;
 
   if (resSerial != res) {
     passed = false;
 
-    std::cout << "Loop<" << typeid(T).name() << ">( test = WrappingIncAtomicTest"
+    std::cout << "Loop<" << typeid(T).name() << ">( test = IncModAtomicTest"
               << " FAILED : " << resSerial << " != " << res << std::endl;
   }
 
@@ -601,11 +601,11 @@ bool DecAtomicTest(T i0) {
 }
 
 //---------------------------------------------------
-//-------------atomic_wrapping_decrement-------------
+//-------------atomic_dec_mod------------------------
 //---------------------------------------------------
 
 template <class T, class DEVICE_TYPE>
-struct WrappingDecFunctor {
+struct DecModFunctor {
   typedef DEVICE_TYPE execution_space;
   typedef Kokkos::View<T, execution_space> type;
 
@@ -619,11 +619,11 @@ struct WrappingDecFunctor {
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 
-  WrappingDecFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
+  DecModFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
 };
 
 template <class T, class execution_space>
-T WrappingDecAtomic(T i0, T i1) {
+T DecModAtomic(T i0, T i1) {
   struct InitFunctor<T, execution_space> f_init(i0);
   typename InitFunctor<T, execution_space>::type data("Data");
   typename InitFunctor<T, execution_space>::h_type h_data("HData");
@@ -632,7 +632,7 @@ T WrappingDecAtomic(T i0, T i1) {
   Kokkos::parallel_for(1, f_init);
   execution_space().fence();
 
-  struct WrappingDecFunctor<T, execution_space> f(i0, i1);
+  struct DecModFunctor<T, execution_space> f(i0, i1);
 
   f.data = data;
   Kokkos::parallel_for(1, f);
@@ -645,7 +645,7 @@ T WrappingDecAtomic(T i0, T i1) {
 }
 
 template <class T>
-T WrappingDecAtomicCheck(T i0, T i1) {
+T DecModAtomicCheck(T i0, T i1) {
   T* data = new T[1];
   data[0] = 0;
 
@@ -660,16 +660,16 @@ T WrappingDecAtomicCheck(T i0, T i1) {
 }
 
 template <class T, class DeviceType>
-bool WrappingDecAtomicTest(T i0, T i1) {
-  T res = WrappingDecAtomic<T, DeviceType>(i0, i1);
-  T resSerial = WrappingDecAtomicCheck<T>(i0, i1);
+bool DecModAtomicTest(T i0, T i1) {
+  T res = DecModAtomic<T, DeviceType>(i0, i1);
+  T resSerial = DecModAtomicCheck<T>(i0, i1);
 
   bool passed = true;
 
   if (resSerial != res) {
     passed = false;
 
-    std::cout << "Loop<" << typeid(T).name() << ">( test = WrappingDecAtomicTest"
+    std::cout << "Loop<" << typeid(T).name() << ">( test = DecModAtomicTest"
               << " FAILED : " << resSerial << " != " << res << std::endl;
   }
 
@@ -1314,9 +1314,9 @@ template <class T, class DeviceType>
 bool AtomicOperationsTestUnsignedIntegralType(int i0, int i1, int test) {
   switch (test) {
     case 1:
-      return WrappingIncAtomicTest<T, DeviceType>((T)i0, (T)i1);
+      return IncModAtomicTest<T, DeviceType>((T)i0, (T)i1);
     case 2:
-      return WrappingDecAtomicTest<T, DeviceType>((T)i0, (T)i1);
+      return DecModAtomicTest<T, DeviceType>((T)i0, (T)i1);
   }
 
   return 0;

--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -467,7 +467,7 @@ struct WrappingIncFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const {
-    desul::atomic_wrapping_fetch_inc(
+    desul::atomic_fetch_wrapping_inc(
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 
@@ -615,7 +615,7 @@ struct WrappingDecFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const {
-    desul::atomic_wrapping_fetch_dec(
+    desul::atomic_fetch_wrapping_dec(
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 

--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -467,7 +467,7 @@ struct WrappingIncFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const {
-    desul::atomic_fetch_wrapping_inc(
+    desul::atomic_fetch_inc_mod(
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 
@@ -615,7 +615,7 @@ struct WrappingDecFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const {
-    desul::atomic_fetch_wrapping_dec(
+    desul::atomic_fetch_dec_mod(
         &data(), (T)i1, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
   }
 


### PR DESCRIPTION
Rename `atomic_wrapping_fetch_{inc,dec} -> atomic_fetch_wrapping_{inc,dec}` or something similar.

* it is more accurate because the wrapping adjectives apply to the operation "increment" or "decrement" not to "fetch".
* the current name gets in the way of efficiently using macros (see changes to HIP atomics)