### PR TITLE
Fix error in SYCL desul atomics due to compiler update

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -22,8 +22,9 @@ namespace desul {
 
 template <class MemoryOrder, class MemoryScope>
 inline void atomic_thread_fence(MemoryOrder, MemoryScope) {
-  sycl::atomic_fence(Impl::DesulToSYCLMemoryOrder<MemoryOrder>::value,
-                     Impl::DesulToSYCLMemoryScope<MemoryScope>::value);
+  sycl::atomic_fence(
+      Impl::DesulToSYCLMemoryOrder<MemoryOrder, /*extended namespace*/ false>::value,
+      Impl::DesulToSYCLMemoryScope<MemoryScope, /*extended namespace*/ false>::value);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>

--- a/atomics/include/desul/atomics/SYCLConversions.hpp
+++ b/atomics/include/desul/atomics/SYCLConversions.hpp
@@ -25,49 +25,63 @@ namespace sycl_sync_and_atomics = ::sycl::ext::oneapi;
 namespace sycl_sync_and_atomics = ::sycl;
 #endif
 
-using sycl_memory_order = sycl_sync_and_atomics::memory_order;
-using sycl_memory_scope = sycl_sync_and_atomics::memory_scope;
+template <bool extended_namespace>
+using sycl_memory_order = std::conditional_t<extended_namespace,
+                                             sycl_sync_and_atomics::memory_order,
+                                             sycl::memory_order>;
+template <bool extended_namespace>
+using sycl_memory_scope = std::conditional_t<extended_namespace,
+                                             sycl_sync_and_atomics::memory_scope,
+                                             sycl::memory_scope>;
 
-template <class MemoryOrder>
+template <class MemoryOrder, bool extended_namespace = true>
 struct DesulToSYCLMemoryOrder;
-template <>
-struct DesulToSYCLMemoryOrder<MemoryOrderSeqCst> {
-  static constexpr sycl_memory_order value = sycl_memory_order::seq_cst;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryOrder<MemoryOrderSeqCst, extended_namespace> {
+  static constexpr sycl_memory_order<extended_namespace> value =
+      sycl_memory_order<extended_namespace>::seq_cst;
 };
-template <>
-struct DesulToSYCLMemoryOrder<MemoryOrderAcquire> {
-  static constexpr sycl_memory_order value = sycl_memory_order::acquire;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryOrder<MemoryOrderAcquire, extended_namespace> {
+  static constexpr sycl_memory_order<extended_namespace> value =
+      sycl_memory_order<extended_namespace>::acquire;
 };
-template <>
-struct DesulToSYCLMemoryOrder<MemoryOrderRelease> {
-  static constexpr sycl_memory_order value = sycl_memory_order::release;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryOrder<MemoryOrderRelease, extended_namespace> {
+  static constexpr sycl_memory_order<extended_namespace> value =
+      sycl_memory_order<extended_namespace>::release;
 };
-template <>
-struct DesulToSYCLMemoryOrder<MemoryOrderAcqRel> {
-  static constexpr sycl_memory_order value = sycl_memory_order::acq_rel;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryOrder<MemoryOrderAcqRel, extended_namespace> {
+  static constexpr sycl_memory_order<extended_namespace> value =
+      sycl_memory_order<extended_namespace>::acq_rel;
 };
-template <>
-struct DesulToSYCLMemoryOrder<MemoryOrderRelaxed> {
-  static constexpr sycl_memory_order value = sycl_memory_order::relaxed;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryOrder<MemoryOrderRelaxed, extended_namespace> {
+  static constexpr sycl_memory_order<extended_namespace> value =
+      sycl_memory_order<extended_namespace>::relaxed;
 };
 
-template <class MemoryScope>
+template <class MemoryScope, bool extended_namespace = true>
 struct DesulToSYCLMemoryScope;
-template <>
-struct DesulToSYCLMemoryScope<MemoryScopeCore> {
-  static constexpr sycl_memory_scope value = sycl_memory_scope::work_group;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryScope<MemoryScopeCore, extended_namespace> {
+  static constexpr sycl_memory_scope<extended_namespace> value =
+      sycl_memory_scope<extended_namespace>::work_group;
 };
-template <>
-struct DesulToSYCLMemoryScope<MemoryScopeDevice> {
-  static constexpr sycl_memory_scope value = sycl_memory_scope::device;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryScope<MemoryScopeDevice, extended_namespace> {
+  static constexpr sycl_memory_scope<extended_namespace> value =
+      sycl_memory_scope<extended_namespace>::device;
 };
-template <>
-struct DesulToSYCLMemoryScope<MemoryScopeSystem> {
-  static constexpr sycl_memory_scope value = sycl_memory_scope::system;
+template <bool extended_namespace>
+struct DesulToSYCLMemoryScope<MemoryScopeSystem, extended_namespace> {
+  static constexpr sycl_memory_scope<extended_namespace> value =
+      sycl_memory_scope<extended_namespace>::system;
 };
 
 template <class T, class MemoryOrder, class MemoryScope>
-using sycl_atomic_ref = sycl_sync_and_atomics::atomic_ref<
+using sycl_atomic_ref = sycl::ext::oneapi::atomic_ref<
     T,
     DesulToSYCLMemoryOrder<MemoryOrder>::value,
     DesulToSYCLMemoryScope<MemoryScope>::value,


### PR DESCRIPTION
This corresponds to https://github.com/kokkos/kokkos/pull/4493. From https://github.com/kokkos/kokkos/pull/4493#issuecomment-957935738:
> We are testing with the nightly release from 2021/09/03 which could be used with namespace sycl::ext::oneapi consistently for the atomics without deprecation warnings. Now, I need to use the sycl namespace for atomic_fence (including its arguments) but the other atomic functions (like atomic_ref) are in namespace sycl::ext::oneapi (sycl::ONEAPI also exists) including their arguments. Note that both atomic_fence and atomic_ref take memory_order and memory_scope arguments (in different namespaces for atomic_fence and atomic_ref in Intel's implementation).
>
>TL;DR We need to use namespace sycl for atomic_fence and its arguments and namespace sycl::ext::oneapi for atomic_ref and its arguments. This pull request allows choosing the namespace used in the conversions from desul names to sycl names.