### PR TITLE
Fix SYCL atomics for local memory

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -27,13 +27,131 @@ inline void atomic_thread_fence(MemoryOrder, MemoryScope) {
       Impl::DesulToSYCLMemoryScope<MemoryScope, /*extended namespace*/ false>::value);
 }
 
+// FIXME_SYCL We need to either use generic_space or figure out how to check for the
+// correct adress space in a SYCL-portable way.
+#ifndef __NVPTX__
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
-      *reinterpret_cast<unsigned int*>(dest));
+  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned int>(dest);
+  if (l) {
+    Impl::sycl_atomic_ref<unsigned int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::local_space>
+    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+    dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
+                                     *reinterpret_cast<unsigned int*>(&value));
+    return compare;
+  } else {
+    Impl::sycl_atomic_ref<unsigned int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::global_space>
+    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+    dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
+                                     *reinterpret_cast<unsigned int*>(&value));
+    return compare;
+  }
+}
+template <typename T, class MemoryOrder, class MemoryScope>
+typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long is 64-bit");
+  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned long long int>(dest);
+  if (l) {
+    Impl::sycl_atomic_ref<unsigned long long int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::local_space>
+    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+    dest_ref.compare_exchange_strong(
+        *reinterpret_cast<unsigned long long int*>(&compare),
+        *reinterpret_cast<unsigned long long int*>(&value));
+    return compare;
+  } else {
+    Impl::sycl_atomic_ref<unsigned long long int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::global_space>
+    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+    dest_ref.compare_exchange_strong(
+        *reinterpret_cast<unsigned long long int*>(&compare),
+        *reinterpret_cast<unsigned long long int*>(&value));
+    return compare;
+  }
+}
+
+template <typename T, class MemoryOrder, class MemoryScope>
+typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
+                                                                 T value,
+                                                                 MemoryOrder,
+                                                                 MemoryScope) {
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned int>(dest);
+  if (l) {
+    Impl::sycl_atomic_ref<unsigned int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::local_space>
+    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+    unsigned int return_val =
+        dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
+    return reinterpret_cast<T&>(return_val);
+  } else {
+    Impl::sycl_atomic_ref<unsigned int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::global_space>
+    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+    unsigned int return_val =
+        dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
+    return reinterpret_cast<T&>(return_val);
+  }
+}
+template <typename T, class MemoryOrder, class MemoryScope>
+typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
+                                                                 T value,
+                                                                 MemoryOrder,
+                                                                 MemoryScope) {
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long is 64-bit");
+  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned long long int>(dest);
+  if (l) {
+    Impl::sycl_atomic_ref<unsigned long long int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::local_space>
+    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+    unsigned long long int return_val =
+        dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
+    return reinterpret_cast<T&>(return_val);
+  } else {
+    Impl::sycl_atomic_ref<unsigned long long int,
+                          MemoryOrder,
+                          MemoryScopeDevice,
+                          sycl::access::address_space::global_space>
+    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+    unsigned long long int return_val =
+        dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
+    return reinterpret_cast<T&>(return_val);
+  }
+}
+#else
+template <typename T, class MemoryOrder, class MemoryScope>
+typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+  Impl::sycl_atomic_ref<unsigned int,
+                        MemoryOrder,
+                        MemoryScope,
+                        sycl::access::address_space::global_space>
+  dest_ref(*reinterpret_cast<unsigned int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                    *reinterpret_cast<unsigned int*>(&value));
   return compare;
@@ -43,8 +161,11 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
                 "this function assumes an unsigned long long is 64-bit");
-  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
-      *reinterpret_cast<unsigned long long int*>(dest));
+  Impl::sycl_atomic_ref<unsigned long long int,
+                        MemoryOrder,
+                        MemoryScope,
+                        sycl::access::address_space::global_space>
+  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
                                    *reinterpret_cast<unsigned long long int*>(&value));
   return compare;
@@ -57,8 +178,11 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
                                                                  MemoryScope) {
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
-      *reinterpret_cast<unsigned int*>(dest));
+  Impl::sycl_atomic_ref<unsigned int,
+                        MemoryOrder,
+                        MemoryScope,
+                        sycl::access::address_space::global_space>
+  dest_ref(*reinterpret_cast<unsigned int*>(dest));
   unsigned int return_val = dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
@@ -69,12 +193,16 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                                                                  MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
                 "this function assumes an unsigned long long is 64-bit");
-  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
-      *reinterpret_cast<unsigned long long int*>(dest));
+  Impl::sycl_atomic_ref<unsigned long long int,
+                        MemoryOrder,
+                        MemoryScope,
+                        sycl::access::address_space::global_space>
+  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
       dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
   return reinterpret_cast<T&>(return_val);
 }
+#endif
 
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type

--- a/atomics/include/desul/atomics/SYCL.hpp
+++ b/atomics/include/desul/atomics/SYCL.hpp
@@ -17,17 +17,69 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 namespace desul {
 
+// FIXME_SYCL We need to either use generic_space or figure out how to check for the
+// correct adress space in a SYCL-portable way.
+#ifndef __NVPTX__
 #define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                              \
   template <class MemoryOrder>                                                     \
   TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
-    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<TYPE>(dest);                  \
+    if (l) {                                                                       \
+      Impl::sycl_atomic_ref<TYPE,                                                  \
+                            MemoryOrder,                                           \
+                            MemoryScopeDevice,                                     \
+                            sycl::access::address_space::local_space>              \
+          dest_ref(*dest);                                                         \
+      return dest_ref.fetch_##OPER(val);                                           \
+    } else {                                                                       \
+      Impl::sycl_atomic_ref<TYPE,                                                  \
+                            MemoryOrder,                                           \
+                            MemoryScopeDevice,                                     \
+                            sycl::access::address_space::global_space>             \
+          dest_ref(*dest);                                                         \
+      return dest_ref.fetch_##OPER(val);                                           \
+    }                                                                              \
+  }                                                                                \
+  template <class MemoryOrder>                                                     \
+  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore) {   \
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<TYPE>(dest);                  \
+    if (l) {                                                                       \
+      Impl::sycl_atomic_ref<TYPE,                                                  \
+                            MemoryOrder,                                           \
+                            MemoryScopeDevice,                                     \
+                            sycl::access::address_space::local_space>              \
+          dest_ref(*dest);                                                         \
+      return dest_ref.fetch_##OPER(val);                                           \
+    } else {                                                                       \
+      Impl::sycl_atomic_ref<TYPE,                                                  \
+                            MemoryOrder,                                           \
+                            MemoryScopeDevice,                                     \
+                            sycl::access::address_space::global_space>             \
+          dest_ref(*dest);                                                         \
+      return dest_ref.fetch_##OPER(val);                                           \
+    }                                                                              \
+  }
+#else
+#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                              \
+  template <class MemoryOrder>                                                     \
+  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
+    Impl::sycl_atomic_ref<TYPE,                                                    \
+                          MemoryOrder,                                             \
+                          MemoryScopeDevice,                                       \
+                          sycl::access::address_space::global_space>               \
+        dest_ref(*dest);                                                           \
     return dest_ref.fetch_##OPER(val);                                             \
   }                                                                                \
   template <class MemoryOrder>                                                     \
   TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore) {   \
-    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    Impl::sycl_atomic_ref<TYPE,                                                    \
+                          MemoryOrder,                                             \
+                          MemoryScopeCore,                                         \
+                          sycl::access::address_space::global_space>               \
+        dest_ref(*dest);                                                           \
     return dest_ref.fetch_##OPER(val);                                             \
   }
+#endif
 
 #define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(OPER) \
   DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, int)           \

--- a/atomics/include/desul/atomics/SYCLConversions.hpp
+++ b/atomics/include/desul/atomics/SYCLConversions.hpp
@@ -80,20 +80,15 @@ struct DesulToSYCLMemoryScope<MemoryScopeSystem, extended_namespace> {
       sycl_memory_scope<extended_namespace>::system;
 };
 
-template <class T, class MemoryOrder, class MemoryScope>
-using sycl_atomic_ref = sycl::ext::oneapi::atomic_ref<
-    T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScope>::value,
-    // FIXME In SYCL 2020 Specification (revision 3) the class template atomic_ref has
-    // its trailing (non-type) template parameter defaulted to
-    // access::address_space::generic_space, but in currently available implementations
-    // a/ the template parameter has no default template argument, and b/ the
-    // generic_space enumerator is not a valid address space (only global_space,
-    // local_space, and global_space are).  Worse it is not yet defined as part of the
-    // access::address_space enumerator list.
-    // Here we arbitrarily elected to use global_space as a temporary workaround.
-    sycl::access::address_space::global_space>;
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          sycl::access::address_space AddressSpace>
+using sycl_atomic_ref =
+    sycl::ext::oneapi::atomic_ref<T,
+                                  DesulToSYCLMemoryOrder<MemoryOrder>::value,
+                                  DesulToSYCLMemoryScope<MemoryScope>::value,
+                                  AddressSpace>;
 
 }  // namespace Impl
 }  // namespace desul


### PR DESCRIPTION
This pull request corresponds to https://github.com/kokkos/kokkos/pull/4585. Basically, the atomics don't do anything for `SYCL` local memory right now and this pull request introduces a check for the correct address space (if the SYCL backend is not CUDA).