### PR TITLE
Fix bug in HIP atomics

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
@@ -13,7 +13,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
 namespace desul {
-#if defined(__HIP_DEVICE_COMPILE__)
 inline __device__ void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
   __threadfence();
 }
@@ -172,10 +171,9 @@ atomic_compare_exchange(
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION __device__
-    typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
-    atomic_compare_exchange(
-        T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
+__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
+atomic_compare_exchange(
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
@@ -202,9 +200,8 @@ DESUL_INLINE_FUNCTION __device__
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION __device__
-    typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
-    atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
+__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
+atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
@@ -227,7 +224,6 @@ DESUL_INLINE_FUNCTION __device__
   }
   return return_val;
 }
-#endif
 }  // namespace desul
 #endif
 #endif

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -23,6 +23,8 @@ namespace Impl {
 
 #ifdef __HIP_DEVICE_COMPILE__
 #define DESUL_IMPL_BALLOT_MASK(x) __ballot(x)
+#else
+#define DESUL_IMPL_BALLOT_MASK(x) 0
 #endif
 
 /**


### PR DESCRIPTION
There is a bug in the HIP backend. The code was adapted from the CUDA code using `NVCC` instead of the one using `CUDA-Clang`

Related to https://github.com/kokkos/kokkos/pull/4819