### PR TITLE
Install desul atomics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 ﻿cmake_minimum_required (VERSION 3.10)
 
-project(DESUL CXX)
+project(desul
+  LANGUAGES CXX
+  VERSION 0.1.0)
 
 # Default to C++14 if not set TODO: check to ensure this is the minimum
 if (NOT BLT_CXX_STD)
@@ -28,3 +30,4 @@ MACRO(APPEND_GLOB VAR)
 ENDMACRO()
 
 add_subdirectory(atomics)
+

--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -12,12 +12,12 @@ ENDMACRO()
 # APPEND_GLOB(DESUL_ATOMIC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 if(ENABLE_CUDA)
   set(DESUL_CUDA_ATOMICS_SOURCES src/Lock_Array_CUDA.cpp)
-  set(SOURCES_ARG SOURCES ${DESUL_CUDA_ATOMICS_SOURCES})
+  set(SOURCES_ARG ${DESUL_CUDA_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON cuda)
 endif()
 if(ENABLE_HIP)
   set(DESUL_HIP_ATOMICS_SOURCES src/Lock_Array_HIP.cpp)
-  set(SOURCES_ARG SOURCES ${DESUL_HIP_ATOMICS_SOURCES})
+  set(SOURCES_ARG ${DESUL_HIP_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON hip)
 endif()
 
@@ -30,6 +30,30 @@ blt_add_library(NAME desul_atomics
                 ${SOURCES_ARG}
                 INCLUDES ${INCLUDES_ARG}
                 ${DEPENDS_ARG})
+target_include_directories (desul_atomics PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${PROJECT_SOURCE_DIR}/atomics/desul_atomicsConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/desul_atomicsConfig.cmake
+  PATH_VARS CMAKE_INSTALL_PREFIX
+  INSTALL_DESTINATION lib/cmake/desul)
+
+install(FILES
+  ${PROJECT_BINARY_DIR}/desul_atomicsConfig.cmake
+  DESTINATION lib/cmake/desul)
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/desul_atomics-config-version.cmake
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}/desul_atomics-config-version.cmake"
+  DESTINATION lib/cmake/desul)
 
 # Install options
 install(TARGETS desul_atomics
@@ -48,7 +72,5 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/atomics/include/
   PATTERN *.hpp
   PATTERN *.inc)
 
-
-  # TODO: Add tests and install targets if needed.
 add_subdirectory(unit_tests)
 add_subdirectory(performance_tests)

--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -27,7 +27,7 @@ set(INCLUDES_ARG
 
 blt_add_library(NAME desul_atomics
                 HEADERS include/desul/atomics.hpp
-                ${SOURCES_ARG}
+                SOURCES src/common.cpp ${SOURCES_ARG}
                 INCLUDES ${INCLUDES_ARG}
                 ${DEPENDS_ARG})
 target_include_directories (desul_atomics PUBLIC

--- a/atomics/desul_atomicsConfig.cmake.in
+++ b/atomics/desul_atomicsConfig.cmake.in
@@ -2,7 +2,7 @@
 
 set(desul_atomics_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@" CACHE FILEPATH "camp install prefix path")
 
-include("${CMAKE_CURRENT_LIST_DIR}/desul_atomics_targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/desul_atomics.cmake")
 # check_required_components("@PROJECT_NAME@")
 check_required_components("desul_atomics")
 

--- a/atomics/desul_atomicsConfig.cmake.in
+++ b/atomics/desul_atomicsConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set(desul_atomics_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@" CACHE FILEPATH "camp install prefix path")
+
+include("${CMAKE_CURRENT_LIST_DIR}/desul_atomics_targets.cmake")
+# check_required_components("@PROJECT_NAME@")
+check_required_components("desul_atomics")
+


### PR DESCRIPTION
This should take care of the find_project support as we discussed.  The one bit of strangeness in here is that I couldn't coerce cmake into letting me set the target properties properly without at least one source file there in all cases, so for now the host has a stub empty `common.cpp` file.  Since we require compiled components for cuda and hip, we may as well just do it everywhere and pull the compile-times down some by moving some things in there, but this is there to work around the cmake issue for now.