### PR TITLE
Avoid macros for CUDA lock arrays

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
@@ -76,7 +76,7 @@ namespace Impl {
 /// instances in other translation units, we must update this CUDA global
 /// variable based on the Host global variable prior to running any kernels
 /// that will use it.
-/// That is the purpose of the KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE macro.
+/// That is the purpose of the ensure_cuda_lock_arrays_on_device function.
 __device__
 #ifdef __CUDACC_RDC__
     __constant__ extern
@@ -138,33 +138,41 @@ namespace {
 static int lock_array_copied = 0;
 inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
-}  // namespace Impl
-}  // namespace desul
-/* It is critical that this code be a macro, so that it will
-   capture the right address for desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE
-   putting this in an inline function will NOT do the right thing! */
-#define DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE()                       \
-  {                                                                        \
-    if (::desul::Impl::lock_array_copied == 0) {                           \
-      cudaMemcpyToSymbol(::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE,    \
-                         &::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h, \
-                         sizeof(int32_t*));                                \
-      cudaMemcpyToSymbol(::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE,      \
-                         &::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE_h,   \
-                         sizeof(int32_t*));                                \
-    }                                                                      \
-    ::desul::Impl::lock_array_copied = 1;                                  \
+
+#ifdef __CUDACC_RDC__
+inline
+#else
+static
+#endif
+    void
+    copy_cuda_lock_arrays_to_device() {
+  if (lock_array_copied == 0) {
+    cudaMemcpyToSymbol(CUDA_SPACE_ATOMIC_LOCKS_DEVICE,
+                       &CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h,
+                       sizeof(int32_t*));
+    cudaMemcpyToSymbol(CUDA_SPACE_ATOMIC_LOCKS_NODE,
+                       &CUDA_SPACE_ATOMIC_LOCKS_NODE_h,
+                       sizeof(int32_t*));
   }
+  lock_array_copied = 1;
+}
+
+}  // namespace Impl
 
 #endif /* defined( __CUDACC__ ) */
 
 #endif /* defined( DESUL_HAVE_CUDA_ATOMICS ) */
 
+namespace desul {
+
 #if defined(__CUDACC_RDC__) || (!defined(__CUDACC__))
-#define DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE()
+inline void ensure_cuda_lock_arrays_on_device() {}
 #else
-#define DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE() \
-  DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE()
+static inline void ensure_cuda_lock_arrays_on_device() {
+  Impl::copy_cuda_lock_arrays_to_device();
+}
 #endif
 
-#endif /* #ifndef KOKKOS_CUDA_LOCKS_HPP_ */
+}  // namespace desul
+
+#endif /* #ifndef DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_ */

--- a/atomics/performance_tests/kokkos_based/PerfTestAtomicsLoc.inc
+++ b/atomics/performance_tests/kokkos_based/PerfTestAtomicsLoc.inc
@@ -1,13 +1,23 @@
 
-#define COMBINE(A,B,C,D,E,F) A ## _ ## B ## _ ## C ## _ ## D ## _ ## E ## _ ## F
-#define INDIRECTION(A,B,C,D,E,F)  COMBINE(A,B,C,D,E,F)
-#define TESTNAME INDIRECTION(kokkos_random_loc, MEMORY_OP, SCALAR_NAME, EXECUTION_SPACE, MEMORY_ORDER, MEMORY_SCOPE)
+#define COMBINE(A, B, C, D, E, F) A##_##B##_##C##_##D##_##E##_##F
+#define INDIRECTION(A, B, C, D, E, F) COMBINE(A, B, C, D, E, F)
+#define TESTNAME                 \
+  INDIRECTION(kokkos_random_loc, \
+              MEMORY_OP,         \
+              SCALAR_NAME,       \
+              EXECUTION_SPACE,   \
+              MEMORY_ORDER,      \
+              MEMORY_SCOPE)
 
-#define ADD_NS(A,B) A :: B
+#define ADD_NS(A, B) A ::B
 TEST(atomic, TESTNAME) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
-  test_atomic_perf_random_loc<SCALAR,MEMORY_OP<ADD_NS(desul,MEMORY_ORDER),ADD_NS(desul,MEMORY_SCOPE)>,ADD_NS(Kokkos,EXECUTION_SPACE),ADD_NS(Kokkos,MEMORY_SPACE)>(1000000);
+  test_atomic_perf_random_loc<
+      SCALAR,
+      MEMORY_OP<ADD_NS(desul, MEMORY_ORDER), ADD_NS(desul, MEMORY_SCOPE)>,
+      ADD_NS(Kokkos, EXECUTION_SPACE),
+      ADD_NS(Kokkos, MEMORY_SPACE)>(1000000);
 }
 #undef ADD_NS
 #undef TESTNAME

--- a/atomics/performance_tests/kokkos_based/PerfTestAtomicsNeigh.inc
+++ b/atomics/performance_tests/kokkos_based/PerfTestAtomicsNeigh.inc
@@ -1,13 +1,23 @@
 
-#define COMBINE(A,B,C,D,E,F) A ## _ ## B ## _ ## C ## _ ## D ## _ ## E ## _ ## F
-#define INDIRECTION(A,B,C,D,E,F)  COMBINE(A,B,C,D,E,F)
-#define TESTNAME INDIRECTION(kokkos_random_neigh, MEMORY_OP, SCALAR_NAME, EXECUTION_SPACE, MEMORY_ORDER, MEMORY_SCOPE)
+#define COMBINE(A, B, C, D, E, F) A##_##B##_##C##_##D##_##E##_##F
+#define INDIRECTION(A, B, C, D, E, F) COMBINE(A, B, C, D, E, F)
+#define TESTNAME                   \
+  INDIRECTION(kokkos_random_neigh, \
+              MEMORY_OP,           \
+              SCALAR_NAME,         \
+              EXECUTION_SPACE,     \
+              MEMORY_ORDER,        \
+              MEMORY_SCOPE)
 
-#define ADD_NS(A,B) A :: B
+#define ADD_NS(A, B) A ::B
 TEST(atomic, TESTNAME) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
-  test_atomic_perf_random_neighs<SCALAR,MEMORY_OP<ADD_NS(desul,MEMORY_ORDER),ADD_NS(desul,MEMORY_SCOPE)>,ADD_NS(Kokkos,EXECUTION_SPACE),ADD_NS(Kokkos,MEMORY_SPACE)>(1000000);
+  test_atomic_perf_random_neighs<
+      SCALAR,
+      MEMORY_OP<ADD_NS(desul, MEMORY_ORDER), ADD_NS(desul, MEMORY_SCOPE)>,
+      ADD_NS(Kokkos, EXECUTION_SPACE),
+      ADD_NS(Kokkos, MEMORY_SPACE)>(1000000);
 }
 #undef ADD_NS
 #undef TESTNAME

--- a/atomics/performance_tests/kokkos_based/UnitTestMainInit.cpp
+++ b/atomics/performance_tests/kokkos_based/UnitTestMainInit.cpp
@@ -43,18 +43,17 @@
 */
 
 #include <gtest/gtest.h>
-#include <cstdlib>
 
-#include <desul/atomics.hpp>
 #include <Kokkos_Core.hpp>
-
+#include <cstdlib>
+#include <desul/atomics.hpp>
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   desul::Impl::init_lock_arrays();
 
 #ifdef DESUL_HAVE_CUDA_ATOMICS
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS

--- a/atomics/performance_tests/kokkos_based/double_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/double_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_double) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<double,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_double) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<double,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/performance_tests/kokkos_based/float_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/float_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_float) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<float,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_float) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<float,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/performance_tests/kokkos_based/int32_t_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/int32_t_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_int32_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<int32_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_int32_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<int32_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/performance_tests/kokkos_based/int64_t_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/int64_t_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_int64_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<int64_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_int64_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<int64_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/performance_tests/kokkos_based/uint32_t_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/uint32_t_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_uint32_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<uint32_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_uint32_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<uint32_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/performance_tests/kokkos_based/uint64_t_neigh.cpp
+++ b/atomics/performance_tests/kokkos_based/uint64_t_neigh.cpp
@@ -89,11 +89,11 @@
 #define MEMORY_SCOPE desul::MemoryScopeDevice
 namespace Test {
 TEST(atomic, kokkos_perf_random_loc_add_uint64_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_loc<uint64_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(10000000);
 }
 TEST(atomic, kokkos_perf_random_neigh_add_uint64_t) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   test_atomic_perf_random_neighs<uint64_t,atomic_add_opp,Kokkos::DefaultExecutionSpace,Kokkos::DefaultExecutionSpace::memory_space>(1000000);
 }
 

--- a/atomics/src/Lock_Array_CUDA.cpp
+++ b/atomics/src/Lock_Array_CUDA.cpp
@@ -70,7 +70,7 @@ void init_lock_arrays_cuda() {
                              "init_lock_arrays_cuda: cudaMalloc host locks");
 
   auto error_sync1 = cudaDeviceSynchronize();
-  DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();
+  copy_cuda_lock_arrays_to_device();
   check_error_and_throw_cuda(error_sync1, "init_lock_arrays_cuda: post mallocs");
   init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
   auto error_sync2 = cudaDeviceSynchronize();
@@ -85,7 +85,7 @@ void finalize_lock_arrays_cuda() {
   CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 #ifdef __CUDACC_RDC__
-  DESUL_IMPL_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();
+  copy_cuda_lock_arrays_to_device();
 #endif
 }
 

--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -43,8 +43,9 @@
 */
 
 #include <gtest/gtest.h>
-#include <desul/atomics.hpp>
+
 #include <Kokkos_Core.hpp>
+#include <desul/atomics.hpp>
 
 #define TEST_CATEGORY kokkos_default
 #define TEST_EXECSPACE Kokkos::DefaultExecutionSpace
@@ -232,7 +233,6 @@ bool MinAtomicTest(T i0, T i1) {
 
   return passed;
 }
-
 
 //---------------------------------------------------
 //--------------atomic_add---------------------
@@ -1301,9 +1301,9 @@ bool AtomicOperationsTestIntegralType(int i0, int i1, int test) {
       return IncAtomicTest<T, DeviceType>((T)i0);
     case 12:
       return DecAtomicTest<T, DeviceType>((T)i0);
-    case 13: 
+    case 13:
       return AddAtomicTest<T, DeviceType>((T)i0);
-    case 14: 
+    case 14:
       return SubAtomicTest<T, DeviceType>((T)i0);
   }
 
@@ -1333,9 +1333,9 @@ bool AtomicOperationsTestNonIntegralType(int i0, int i1, int test) {
       return MulAtomicTest<T, DeviceType>((T)i0, (T)i1);
     case 4:
       return DivAtomicTest<T, DeviceType>((T)i0, (T)i1);
-    case 5: 
+    case 5:
       return AddAtomicTest<T, DeviceType>((T)i0);
-    case 6: 
+    case 6:
       return SubAtomicTest<T, DeviceType>((T)i0);
   }
 

--- a/atomics/unit_tests/kokkos_based/UnitTestMainInit.cpp
+++ b/atomics/unit_tests/kokkos_based/UnitTestMainInit.cpp
@@ -43,18 +43,17 @@
 */
 
 #include <gtest/gtest.h>
-#include <cstdlib>
 
-#include <desul/atomics.hpp>
 #include <Kokkos_Core.hpp>
-
+#include <cstdlib>
+#include <desul/atomics.hpp>
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   desul::Impl::init_lock_arrays();
 
 #ifdef DESUL_HAVE_CUDA_ATOMICS
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS

--- a/atomics/unit_tests/kokkos_based/complexdouble.cpp
+++ b/atomics/unit_tests/kokkos_based/complexdouble.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_complexdouble) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/complexfloat.cpp
+++ b/atomics/unit_tests/kokkos_based/complexfloat.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_complexfloat) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/double.cpp
+++ b/atomics/unit_tests/kokkos_based/double.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_double) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 2;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/float.cpp
+++ b/atomics/unit_tests/kokkos_based/float.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_float) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/int.cpp
+++ b/atomics/unit_tests/kokkos_based/int.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_int) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/longint.cpp
+++ b/atomics/unit_tests/kokkos_based/longint.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_long) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/longlongint.cpp
+++ b/atomics/unit_tests/kokkos_based/longlongint.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_longlong) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;

--- a/atomics/unit_tests/kokkos_based/unsignedint.cpp
+++ b/atomics/unit_tests/kokkos_based/unsignedint.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_unsigned) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;
@@ -84,12 +84,14 @@ TEST(TEST_CATEGORY, atomic_operations_unsigned) {
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<unsigned int,
                                                                         TEST_EXECSPACE>(
         start, end - i, 12)));
-    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned int,
-                                                                                TEST_EXECSPACE>(
-        start, end - i, 1))); // Wrapping Inc
-    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned int,
-                                                                                TEST_EXECSPACE>(
-        start, end - i, 2))); // Wrapping Dec
+    ASSERT_TRUE(
+        (TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned int,
+                                                                        TEST_EXECSPACE>(
+            start, end - i, 1)));  // Wrapping Inc
+    ASSERT_TRUE(
+        (TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned int,
+                                                                        TEST_EXECSPACE>(
+            start, end - i, 2)));  // Wrapping Dec
   }
 }
 }  // namespace Test

--- a/atomics/unit_tests/kokkos_based/unsignedlongint.cpp
+++ b/atomics/unit_tests/kokkos_based/unsignedlongint.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, atomic_operations_unsignedlong) {
-  DESUL_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_cuda_lock_arrays_on_device();
   DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
   const int start = 1;  // Avoid zero for division.
   const int end = 11;
@@ -95,14 +95,12 @@ TEST(TEST_CATEGORY, atomic_operations_unsignedlong) {
         (TestAtomicOperations::AtomicOperationsTestIntegralType<unsigned long int,
                                                                 TEST_EXECSPACE>(
             start, end - i, 12)));
-    ASSERT_TRUE(
-        (TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned long int,
-                                                                        TEST_EXECSPACE>(
-            start, end - i, 1))); // Wrapping Inc
-    ASSERT_TRUE(
-        (TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<unsigned long int,
-                                                                        TEST_EXECSPACE>(
-            start, end - i, 2))); // Wrapping Dec
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<
+                 unsigned long int,
+                 TEST_EXECSPACE>(start, end - i, 1)));  // Wrapping Inc
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestUnsignedIntegralType<
+                 unsigned long int,
+                 TEST_EXECSPACE>(start, end - i, 2)));  // Wrapping Dec
   }
 }
 }  // namespace Test


### PR DESCRIPTION
Corresponding to https://github.com/kokkos/kokkos/pull/4682. Trying the suggestion in https://github.com/kokkos/kokkos/issues/2235.