### PR TITLE
Allow using COMPONENTS for finding a desul installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,7 @@ ENDMACRO()
 
 add_subdirectory(atomics)
 
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/desulConfig.cmake"
+  DESTINATION lib/cmake/desul)
+

--- a/cmake/desulConfig.cmake
+++ b/cmake/desulConfig.cmake
@@ -1,0 +1,3 @@
+foreach(component ${desul_FIND_COMPONENTS})
+  include(${CMAKE_CURRENT_LIST_DIR}/desul_${component}Config.cmake)
+endforeach()


### PR DESCRIPTION
Addresses https://github.com/kokkos/kokkos/pull/5053/files#r888299021. Currently, we need syntax like
```
-Ddesul_atomics_ROOT=/usr/desul-install/lib/cmake/desul/ 
```
to find a `desul` installation via `find_package(desul_atomics)`. 

This pull request allows using
```
-Ddesul_ROOT=~/desul-install
```
with `find_package(desul COMPONENTS atomics)` and still 
```
target_link_libraries(kokkoscore PUBLIC desul_atomics)
```
Also, compare https://stackoverflow.com/questions/54702582/how-to-configure-project-with-components-in-cmake.