### PR TITLE
Fix up Lock_Array_Cuda.hpp

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_Cuda.hpp
@@ -158,6 +158,7 @@ static
 }
 
 }  // namespace Impl
+}  // namespace desul
 
 #endif /* defined( __CUDACC__ ) */
 


### PR DESCRIPTION
#64 missed closing the namespace opened in line 135.