### PR TITLE
Replace CL/sycl.hpp

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -13,7 +13,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include "desul/atomics/SYCLConversions.hpp"
 #include "desul/atomics/Common.hpp"
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 // clang-format on
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -13,7 +13,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include "desul/atomics/SYCLConversions.hpp"
 #include "desul/atomics/Common.hpp"
 
-// FIXME_SYCL
+// FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
+// but icpx 2022.1.0 and earlier versions only provide <CL/sycl.hpp>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else

--- a/atomics/include/desul/atomics/SYCLConversions.hpp
+++ b/atomics/include/desul/atomics/SYCLConversions.hpp
@@ -13,7 +13,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 // clang-format off
 #include "desul/atomics/Common.hpp"
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 // clang-format on
 
 namespace desul {

--- a/atomics/include/desul/atomics/SYCLConversions.hpp
+++ b/atomics/include/desul/atomics/SYCLConversions.hpp
@@ -13,7 +13,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 // clang-format off
 #include "desul/atomics/Common.hpp"
 
-// FIXME_SYCL
+// FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
+// but icpx 2022.1.0 and earlier versions only provide <CL/sycl.hpp>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else


### PR DESCRIPTION
`CL/sycl.hpp` is deprecated in favor of `sycl/sycl.hpp`