### PR TITLE
Drop unused `{host,device}_atomic_compare_exchange_{strong,weak}`

### DIFF
--- a/atomics/include/desul/atomics/Generic_Device.hpp
+++ b/atomics/include/desul/atomics/Generic_Device.hpp
@@ -454,42 +454,6 @@ DESUL_INLINE_FUNCTION void device_atomic_dec(T* const dest,
   return device_atomic_sub(dest, T(1), order, scope);
 }
 
-// FIXME
-template <class T,
-          class SuccessMemoryOrder,
-          class FailureMemoryOrder,
-          class MemoryScope>
-DESUL_INLINE_FUNCTION bool device_atomic_compare_exchange_strong(
-    T* const dest,
-    T& expected,
-    T desired,
-    SuccessMemoryOrder success,
-    FailureMemoryOrder /*failure*/,
-    MemoryScope scope) {
-  T const old = device_atomic_compare_exchange(dest, expected, desired, success, scope);
-  if (old != expected) {
-    expected = old;
-    return false;
-  } else {
-    return true;
-  }
-}
-
-template <class T,
-          class SuccessMemoryOrder,
-          class FailureMemoryOrder,
-          class MemoryScope>
-DESUL_INLINE_FUNCTION bool device_atomic_compare_exchange_weak(
-    T* const dest,
-    T& expected,
-    T desired,
-    SuccessMemoryOrder success,
-    FailureMemoryOrder failure,
-    MemoryScope scope) {
-  return device_atomic_compare_exchange_strong(
-      dest, expected, desired, success, failure, scope);
-}
-
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Generic_Host.hpp
+++ b/atomics/include/desul/atomics/Generic_Host.hpp
@@ -436,40 +436,6 @@ inline void host_atomic_dec(T* const dest, MemoryOrder order, MemoryScope scope)
   return host_atomic_sub(dest, T(1), order, scope);
 }
 
-// FIXME
-template <class T,
-          class SuccessMemoryOrder,
-          class FailureMemoryOrder,
-          class MemoryScope>
-inline bool host_atomic_compare_exchange_strong(T* const dest,
-                                                T& expected,
-                                                T desired,
-                                                SuccessMemoryOrder success,
-                                                FailureMemoryOrder /*failure*/,
-                                                MemoryScope scope) {
-  T const old = host_atomic_compare_exchange(dest, expected, desired, success, scope);
-  if (old != expected) {
-    expected = old;
-    return false;
-  } else {
-    return true;
-  }
-}
-
-template <class T,
-          class SuccessMemoryOrder,
-          class FailureMemoryOrder,
-          class MemoryScope>
-inline bool host_atomic_compare_exchange_weak(T* const dest,
-                                              T& expected,
-                                              T desired,
-                                              SuccessMemoryOrder success,
-                                              FailureMemoryOrder failure,
-                                              MemoryScope scope) {
-  return host_atomic_compare_exchange_strong(
-      dest, expected, desired, success, failure, scope);
-}
-
 }  // namespace Impl
 }  // namespace desul
 


### PR DESCRIPTION
The goal is to prepare for upcoming larger PR that refactors our providing host and device fallback implementation (use macros to reduce code duplication in `desul/atomics/Generic_{Device,Host}.hpp`