### PR TITLE
SYCL: Implement generic atomis

### DIFF
--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 option(ENABLE_SYCL "Enable SYCL support" OFF) # option does not actually yet exist on the BLT side
 if(ENABLE_SYCL)
   set(DESUL_ATOMICS_ENABLE_SYCL ON)
+  set(DESUL_SYCL_ATOMICS_SOURCES src/Lock_Array_SYCL.cpp)
+  set(SOURCES_ARG ${DESUL_SYCL_ATOMICS_SOURCES})
 endif()
 if(ENABLE_OPENMP)
   set(DESUL_ATOMICS_ENABLE_OPENMP ON)

--- a/atomics/include/desul/atomics/Adapt_SYCL.hpp
+++ b/atomics/include/desul/atomics/Adapt_SYCL.hpp
@@ -110,10 +110,10 @@ using sycl_atomic_ref = sycl::atomic_ref<T,
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
 // FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
 template <class T>
-using sycl_device_global =
-  sycl::ext::oneapi::experimental::device_global<
-    T, decltype(sycl::ext::oneapi::experimental::properties(
-         sycl::ext::oneapi::experimental::device_image_scope))>;
+using sycl_device_global = sycl::ext::oneapi::experimental::device_global<
+    T,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>;
 #endif
 
 }  // namespace Impl

--- a/atomics/include/desul/atomics/Adapt_SYCL.hpp
+++ b/atomics/include/desul/atomics/Adapt_SYCL.hpp
@@ -106,6 +106,16 @@ using sycl_atomic_ref = sycl::atomic_ref<T,
                                          sycl::access::address_space::generic_space>;
 #endif
 
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+// FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
+template <class T>
+using sycl_device_global =
+  sycl::ext::oneapi::experimental::device_global<
+    T, decltype(sycl::ext::oneapi::experimental::properties(
+         sycl::ext::oneapi::experimental::device_image_scope))>;
+#endif
+
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -11,10 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_SYCL.hpp>
 #include <desul/atomics/Common.hpp>
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
 #include <desul/atomics/Lock_Array_SYCL.hpp>
-#endif
 #include <desul/atomics/Thread_Fence_SYCL.hpp>
 
 // FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
@@ -82,9 +79,7 @@ std::enable_if_t<sizeof(T) == 8, T> device_atomic_exchange(T* const dest,
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T>
 device_atomic_compare_exchange(
-    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
-  // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
@@ -111,19 +106,11 @@ device_atomic_compare_exchange(
     done_active = group_ballot(sg, done);
   }
   return return_val;
-#else
-  (void)dest;
-  (void)value;
-  assert(false);
-  return compare;
-#endif
 }
 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange(
-    T* const dest, T value, MemoryOrder, MemoryScope) {
-  // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+    T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
@@ -148,11 +135,6 @@ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange
     done_active = group_ballot(sg, done);
   }
   return return_val;
-#else
-  (void)dest;
-  assert(false);
-  return value;
-#endif
 }
 
 }  // namespace Impl

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -11,6 +11,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_SYCL.hpp>
 #include <desul/atomics/Common.hpp>
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+#include <desul/atomics/Lock_Array_SYCL.hpp>
+#endif
 #include <desul/atomics/Thread_Fence_SYCL.hpp>
 
 // FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
@@ -78,16 +82,77 @@ std::enable_if_t<sizeof(T) == 8, T> device_atomic_exchange(T* const dest,
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T>
 device_atomic_compare_exchange(
-    T* const /*dest*/, T compare, T /*value*/, MemoryOrder, MemoryScope) {
-  assert(false);  // FIXME_SYCL not implemented
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
+  // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  // This is a way to avoid deadlock in a subgroup
+  T return_val;
+  int done = 0;
+  auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+  using sycl::ext::oneapi::group_ballot;
+  using sycl::ext::oneapi::sub_group_mask;
+  sub_group_mask active = group_ballot(sg, 1);
+  sub_group_mask done_active = group_ballot(sg, 0);
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_sycl((void*)dest, scope)) {
+        if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+          atomic_thread_fence(MemoryOrderRelease(), scope);
+        atomic_thread_fence(MemoryOrderAcquire(), scope);
+        return_val = *dest;
+        if (return_val == compare) {
+          *dest = value;
+          device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        }
+        unlock_address_sycl((void*)dest, scope);
+        done = 1;
+      }
+    }
+    done_active = group_ballot(sg, done);
+  }
+  return return_val;
+#else
+  (void)dest;
+  (void)value;
+  assert(false);
   return compare;
+#endif
 }
 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange(
-    T* const /*dest*/, T value, MemoryOrder, MemoryScope) {
-  assert(false);  // FIXME_SYCL not implemented
+    T* const dest, T value, MemoryOrder, MemoryScope scope) {
+  // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  // This is a way to avoid deadlock in a subgroup
+  T return_val;
+  int done = 0;
+  auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+  using sycl::ext::oneapi::group_ballot;
+  using sycl::ext::oneapi::sub_group_mask;
+  sub_group_mask active = group_ballot(sg, 1);
+  sub_group_mask done_active = group_ballot(sg, 0);
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_sycl((void*)dest, scope)) {
+        if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+          atomic_thread_fence(MemoryOrderRelease(), scope);
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        return_val = *dest;
+        *dest = value;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_sycl((void*)dest, scope);
+        done = 1;
+      }
+    }
+    done_active = group_ballot(sg, done);
+  }
+  return return_val;
+#else
+  (void)dest;
+  assert(false);
   return value;
+#endif
 }
 
 }  // namespace Impl

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -82,7 +82,7 @@ std::enable_if_t<sizeof(T) == 8, T> device_atomic_exchange(T* const dest,
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T>
 device_atomic_compare_exchange(
-    T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
+    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
   // This is a way to avoid deadlock in a subgroup
@@ -121,7 +121,7 @@ device_atomic_compare_exchange(
 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange(
-    T* const dest, T value, MemoryOrder, MemoryScope scope) {
+    T* const dest, T value, MemoryOrder, MemoryScope) {
   // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
   // This is a way to avoid deadlock in a subgroup

--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -17,6 +17,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include <desul/atomics/Lock_Array_HIP.hpp>
 #endif
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+#include <desul/atomics/Lock_Array_SYCL.hpp>
+#endif
 
 namespace desul {
 namespace Impl {
@@ -49,6 +53,11 @@ inline void init_lock_arrays() {
 #ifdef DESUL_HAVE_HIP_ATOMICS
   init_lock_arrays_hip();
 #endif
+
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  init_lock_arrays_sycl();
+#endif
 }
 
 inline void finalize_lock_arrays() {
@@ -58,6 +67,11 @@ inline void finalize_lock_arrays() {
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
   finalize_lock_arrays_hip();
+#endif
+
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  finalize_lock_arrays_sycl();
 #endif
 }
 

--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -53,11 +53,6 @@ inline void init_lock_arrays() {
 #ifdef DESUL_HAVE_HIP_ATOMICS
   init_lock_arrays_hip();
 #endif
-
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
-  init_lock_arrays_sycl();
-#endif
 }
 
 inline void finalize_lock_arrays() {
@@ -67,11 +62,6 @@ inline void finalize_lock_arrays() {
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
   finalize_lock_arrays_hip();
-#endif
-
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
-  finalize_lock_arrays_sycl();
 #endif
 }
 

--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -17,8 +17,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include <desul/atomics/Lock_Array_HIP.hpp>
 #endif
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+// Different from DESUL_HAVE_SYCL_ATOMICS because we need the declaration of
+// the sycl::device_global variables in both compile passes.
+#ifdef SYCL_LANGUAGE_VERSION
 #include <desul/atomics/Lock_Array_SYCL.hpp>
 #endif
 

--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -17,9 +17,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include <desul/atomics/Lock_Array_HIP.hpp>
 #endif
-// Different from DESUL_HAVE_SYCL_ATOMICS because we need the declaration of
-// the sycl::device_global variables in both compile passes.
-#ifdef SYCL_LANGUAGE_VERSION
+#ifdef DESUL_HAVE_SYCL_ATOMICS
 #include <desul/atomics/Lock_Array_SYCL.hpp>
 #endif
 

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -24,6 +24,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+
 /**
  * \brief This global variable in Host space is the central definition of these
  * arrays.
@@ -137,6 +140,25 @@ inline void unlock_address_sycl(void* ptr, desul::MemoryScopeNode) {
       lock_node_ref(SYCL_SPACE_ATOMIC_LOCKS_NODE[offset]);
   lock_node_ref.exchange(0);
 }
+#else
+inline bool lock_address_sycl(void*, desul::MemoryScopeDevice) {
+  assert(false);
+  return false;
+}
+
+inline bool lock_address_sycl(void*, desul::MemoryScopeNode) {
+    assert(false);
+    return false;
+}
+
+inline void unlock_address_sycl(void*, desul::MemoryScopeDevice) {
+assert(false);
+}
+
+inline void unlock_address_sycl(void*, desul::MemoryScopeNode) {
+assert(false);
+}
+#endif
 }  // namespace Impl
 }  // namespace desul
 #endif

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -38,7 +38,7 @@ extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h;
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snapshotted version while also linking against pure Desul
 template <typename /*AlwaysInt*/ = int>
-void init_lock_arrays_sycl();
+void init_lock_arrays_sycl(sycl::queue q);
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        all null pointers, and all array memory has been freed.
@@ -47,7 +47,7 @@ void init_lock_arrays_sycl();
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snapshotted version while also linking against pure Desul
 template <typename /*AlwaysInt*/ = int>
-void finalize_lock_arrays_sycl();
+void finalize_lock_arrays_sycl(sycl::queue q);
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -51,11 +51,15 @@ void init_lock_arrays_sycl(sycl::queue q);
 ///   snapshotted version while also linking against pure Desul
 template <typename /*AlwaysInt*/ = int>
 void finalize_lock_arrays_sycl(sycl::queue q);
-}  // namespace Impl
-}  // namespace desul
 
-namespace desul {
-namespace Impl {
+/**
+ * \brief Alias for sycl::device_global.
+ */
+template <class T>
+using sycl_device_global =
+  sycl::ext::oneapi::experimental::device_global<
+    T, decltype(sycl::ext::oneapi::experimental::properties(
+         sycl::ext::oneapi::experimental::device_image_scope))>;
 
 /**
  * \brief This global variable in SYCL space is what kernels use to get access
@@ -67,16 +71,12 @@ namespace Impl {
  * by initialize_host_sycl_lock_arrays and need not be modified afterwards.
  * FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
  */
-SYCL_EXTERNAL extern sycl::ext::oneapi::experimental::device_global<
-    int32_t*,
-    decltype(sycl::ext::oneapi::experimental::properties(
-        sycl::ext::oneapi::experimental::device_image_scope))>
+SYCL_EXTERNAL extern sycl_device_global<
+    int32_t*>
     SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
 
-SYCL_EXTERNAL extern sycl::ext::oneapi::experimental::device_global<
-    int32_t*,
-    decltype(sycl::ext::oneapi::experimental::properties(
-        sycl::ext::oneapi::experimental::device_image_scope))>
+SYCL_EXTERNAL extern sycl_device_global<
+    int32_t*>
     SYCL_SPACE_ATOMIC_LOCKS_NODE;
 
 #define SYCL_SPACE_ATOMIC_MASK 0x1FFFF

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -11,9 +11,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cstdint>
 
+#include "desul/atomics/Adapt_SYCL.hpp"
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
-#include "desul/atomics/Adapt_SYCL.hpp"
 
 // FIXME_SYCL
 #if __has_include(<sycl/sycl.hpp>)
@@ -62,13 +62,9 @@ void finalize_lock_arrays_sycl(sycl::queue q);
  * declaration here must be extern). This one instance will be initialized
  * by initialize_host_sycl_lock_arrays and need not be modified afterwards.
  */
-SYCL_EXTERNAL extern sycl_device_global<
-    int32_t*>
-    SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+SYCL_EXTERNAL extern sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
 
-SYCL_EXTERNAL extern sycl_device_global<
-    int32_t*>
-    SYCL_SPACE_ATOMIC_LOCKS_NODE;
+SYCL_EXTERNAL extern sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_NODE;
 
 #define SYCL_SPACE_ATOMIC_MASK 0x1FFFF
 
@@ -138,17 +134,13 @@ inline bool lock_address_sycl(void*, MemoryScopeDevice) {
 }
 
 inline bool lock_address_sycl(void*, MemoryScopeNode) {
-    assert(false);
-    return true;
+  assert(false);
+  return true;
 }
 
-inline void unlock_address_sycl(void*, MemoryScopeDevice) {
-assert(false);
-}
+inline void unlock_address_sycl(void*, MemoryScopeDevice) { assert(false); }
 
-inline void unlock_address_sycl(void*, MemoryScopeNode) {
-assert(false);
-}
+inline void unlock_address_sycl(void*, MemoryScopeNode) { assert(false); }
 #endif
 }  // namespace Impl
 }  // namespace desul

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -141,11 +141,13 @@ void finalize_lock_arrays_sycl(sycl::queue q) {
 
 inline bool lock_address_sycl(void*, MemoryScopeDevice) {
   assert(false);
+  // return true so that the CAS loops don't hang.
   return true;
 }
 
 inline bool lock_address_sycl(void*, MemoryScopeNode) {
   assert(false);
+  // return true so that the CAS loops don't hang.
   return true;
 }
 

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -128,6 +128,17 @@ inline void unlock_address_sycl(void* ptr, MemoryScopeNode) {
   lock_node_ref.exchange(0);
 }
 #else
+
+template <typename /*AlwaysInt*/ = int>
+void init_lock_arrays_sycl(sycl::queue q) {
+  assert(false);
+}
+
+template <typename /*AlwaysInt*/ = int>
+void finalize_lock_arrays_sycl(sycl::queue q) {
+  assert(false);
+}
+
 inline bool lock_address_sycl(void*, MemoryScopeDevice) {
   assert(false);
   return true;

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOCK_ARRAY_SYCL_HPP_
+#define DESUL_ATOMICS_LOCK_ARRAY_SYCL_HPP_
+
+#include <cstdint>
+
+#include "desul/atomics/Common.hpp"
+#include "desul/atomics/Macros.hpp"
+
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+namespace desul {
+namespace Impl {
+
+/**
+ * \brief This global variable in Host space is the central definition of these
+ * arrays.
+ */
+extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h;
+extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h;
+
+/// \brief After this call, the g_host_cuda_lock_arrays variable has
+///        valid, initialized arrays.
+///
+/// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snapshotted version while also linking against pure Desul
+template <typename /*AlwaysInt*/ = int>
+void init_lock_arrays_sycl();
+
+/// \brief After this call, the g_host_cuda_lock_arrays variable has
+///        all null pointers, and all array memory has been freed.
+///
+/// This call is idempotent.
+/// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
+///   snapshotted version while also linking against pure Desul
+template <typename /*AlwaysInt*/ = int>
+void finalize_lock_arrays_sycl();
+}  // namespace Impl
+}  // namespace desul
+
+namespace desul {
+namespace Impl {
+
+/**
+ * \brief This global variable in SYCL space is what kernels use to get access
+ * to the lock arrays.
+ *
+ * There is only one single instance of this global variable for the entire
+ * executable, whose definition will be in Kokkos_SYCL_Locks.cpp (and whose
+ * declaration here must then be extern.  This one instance will be initialized
+ * by initialize_host_sycl_lock_arrays and need not be modified afterwards.
+ * FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
+ */
+SYCL_EXTERNAL extern sycl::ext::oneapi::experimental::device_global<
+    int32_t*,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>
+    SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+
+SYCL_EXTERNAL extern sycl::ext::oneapi::experimental::device_global<
+    int32_t*,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>
+    SYCL_SPACE_ATOMIC_LOCKS_NODE;
+
+#define SYCL_SPACE_ATOMIC_MASK 0x1FFFF
+
+/// \brief Acquire a lock for the address
+///
+/// This function tries to acquire the lock for the hash value derived
+/// from the provided ptr. If the lock is successfully acquired the
+/// function returns true. Otherwise it returns false.
+inline bool lock_address_sycl(void* ptr, desul::MemoryScopeDevice) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & SYCL_SPACE_ATOMIC_MASK;
+  sycl::atomic_ref<int32_t,
+                   sycl::memory_order::relaxed,
+                   sycl::memory_scope::device,
+                   sycl::access::address_space::global_space>
+      lock_device_ref(SYCL_SPACE_ATOMIC_LOCKS_DEVICE[offset]);
+  return (0 == lock_device_ref.exchange(1));
+}
+
+inline bool lock_address_sycl(void* ptr, desul::MemoryScopeNode) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & SYCL_SPACE_ATOMIC_MASK;
+  sycl::atomic_ref<int32_t,
+                   sycl::memory_order::relaxed,
+                   sycl::memory_scope::system,
+                   sycl::access::address_space::global_space>
+      lock_node_ref(SYCL_SPACE_ATOMIC_LOCKS_NODE[offset]);
+  return (0 == lock_node_ref.exchange(1));
+}
+
+/**
+ * \brief Release lock for the address
+ *
+ * This function releases the lock for the hash value derived from the provided
+ * ptr. This function should only be called after previously successfully
+ * acquiring a lock with lock_address.
+ */
+inline void unlock_address_sycl(void* ptr, desul::MemoryScopeDevice) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & SYCL_SPACE_ATOMIC_MASK;
+  sycl::atomic_ref<int32_t,
+                   sycl::memory_order::relaxed,
+                   sycl::memory_scope::device,
+                   sycl::access::address_space::global_space>
+      lock_device_ref(SYCL_SPACE_ATOMIC_LOCKS_DEVICE[offset]);
+  lock_device_ref.exchange(0);
+}
+
+inline void unlock_address_sycl(void* ptr, desul::MemoryScopeNode) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & SYCL_SPACE_ATOMIC_MASK;
+  sycl::atomic_ref<int32_t,
+                   sycl::memory_order::relaxed,
+                   sycl::memory_scope::system,
+                   sycl::access::address_space::global_space>
+      lock_node_ref(SYCL_SPACE_ATOMIC_LOCKS_NODE[offset]);
+  lock_node_ref.exchange(0);
+}
+}  // namespace Impl
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
@@ -20,7 +20,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 // FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
 #include <desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp>
-#else
+#elif defined(DESUL_HAVE_SYCL_ATOMICS)
 #include <desul/atomics/Lock_Based_Fetch_Op_Unimplemented.hpp>
 #endif
 

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
@@ -17,7 +17,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include <desul/atomics/Lock_Based_Fetch_Op_HIP.hpp>
 #endif
-#ifdef DESUL_HAVE_SYCL_ATOMICS
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+#include <desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp>
+#else
 #include <desul/atomics/Lock_Based_Fetch_Op_Unimplemented.hpp>
 #endif
 

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op.hpp
@@ -17,11 +17,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef DESUL_HAVE_HIP_ATOMICS
 #include <desul/atomics/Lock_Based_Fetch_Op_HIP.hpp>
 #endif
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
-#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+#ifdef DESUL_HAVE_SYCL_ATOMICS
 #include <desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp>
-#elif defined(DESUL_HAVE_SYCL_ATOMICS)
-#include <desul/atomics/Lock_Based_Fetch_Op_Unimplemented.hpp>
 #endif
 
 #include <desul/atomics/Lock_Based_Fetch_Op_Host.hpp>

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOCK_BASED_FETCH_OP_SYCL_HPP_
+#define DESUL_ATOMICS_LOCK_BASED_FETCH_OP_SYCL_HPP_
+
+#include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Array_SYCL.hpp>
+#include <desul/atomics/Thread_Fence_SYCL.hpp>
+#include <type_traits>
+
+namespace desul {
+namespace Impl {
+
+template <class Oper,
+          class T,
+          class MemoryOrder,
+          class MemoryScope,
+          // equivalent to:
+          //   requires !atomic_always_lock_free(sizeof(T))
+          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
+T device_atomic_fetch_oper(const Oper& op,
+                           T* const dest,
+                           dont_deduce_this_parameter_t<const T> val,
+                           MemoryOrder /*order*/,
+                           MemoryScope scope) {
+  // This is a way to avoid deadlock in a subgroup
+  T return_val;
+  int done = 0;
+  auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+  using sycl::ext::oneapi::group_ballot;
+  using sycl::ext::oneapi::sub_group_mask;
+  sub_group_mask active = group_ballot(sg, 1);
+  sub_group_mask done_active = group_ballot(sg, 0);
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_sycl((void*)dest, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        return_val = *dest;
+        *dest = op.apply(return_val, val);
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_sycl((void*)dest, scope);
+        done = 1;
+      }
+    }
+    done_active = group_ballot(sg, done);
+  }
+  return return_val;
+}
+
+template <class Oper,
+          class T,
+          class MemoryOrder,
+          class MemoryScope,
+          // equivalent to:
+          //   requires !atomic_always_lock_free(sizeof(T))
+          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
+T device_atomic_oper_fetch(const Oper& op,
+                           T* const dest,
+                           dont_deduce_this_parameter_t<const T> val,
+                           MemoryOrder /*order*/,
+                           MemoryScope scope) {
+  // This is a way to avoid deadlock in a subgroup
+  T return_val;
+  int done = 0;
+  auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+  using sycl::ext::oneapi::group_ballot;
+  using sycl::ext::oneapi::sub_group_mask;
+  sub_group_mask active = group_ballot(sg, 1);
+  sub_group_mask done_active = group_ballot(sg, 0);
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_sycl((void*)dest, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        return_val = op.apply(*dest, val);
+        *dest = return_val;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_sycl((void*)dest, scope);
+        done = 1;
+      }
+    }
+    done_active = group_ballot(sg, done);
+  }
+  return return_val;
+}
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/src/Lock_Array_SYCL.cpp
+++ b/atomics/src/Lock_Array_SYCL.cpp
@@ -17,17 +17,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 SYCL_EXTERNAL
-sycl::ext::oneapi::experimental::device_global<
-    int32_t*,
-    decltype(sycl::ext::oneapi::experimental::properties(
-        sycl::ext::oneapi::experimental::device_image_scope))>
-    SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
 SYCL_EXTERNAL
-sycl::ext::oneapi::experimental::device_global<
-    int32_t*,
-    decltype(sycl::ext::oneapi::experimental::properties(
-        sycl::ext::oneapi::experimental::device_image_scope))>
-    SYCL_SPACE_ATOMIC_LOCKS_NODE;
+sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_NODE;
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/src/Lock_Array_SYCL.cpp
+++ b/atomics/src/Lock_Array_SYCL.cpp
@@ -12,16 +12,18 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <cinttypes>
 #include <desul/atomics/Lock_Array_SYCL.hpp>
 
-SYCL_EXTERNAL
-sycl_device_global<int32_t*> desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
-SYCL_EXTERNAL
-sycl_device_global<int32_t*> desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_NODE;
+namespace desul::Impl {
 
-int32_t* desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
-int32_t* desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
+SYCL_EXTERNAL
+sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+SYCL_EXTERNAL
+sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_NODE;
+
+int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
 template <>
-void desul::Impl::init_lock_arrays_sycl<int>(sycl::queue q) {
+void init_lock_arrays_sycl<int>(sycl::queue q) {
   if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
 
   SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h =
@@ -54,7 +56,7 @@ void desul::Impl::init_lock_arrays_sycl<int>(sycl::queue q) {
 }
 
 template <>
-void desul::Impl::finalize_lock_arrays_sycl<int>(sycl::queue q) {
+void finalize_lock_arrays_sycl<int>(sycl::queue q) {
   if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h == nullptr) return;
 
   sycl::free(SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h, q);
@@ -62,4 +64,6 @@ void desul::Impl::finalize_lock_arrays_sycl<int>(sycl::queue q) {
   SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 }
+
+} // namespace desul::Impl
 #endif

--- a/atomics/src/Lock_Array_SYCL.cpp
+++ b/atomics/src/Lock_Array_SYCL.cpp
@@ -12,23 +12,16 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <cinttypes>
 #include <desul/atomics/Lock_Array_SYCL.hpp>
 
-namespace desul {
-namespace Impl {
 SYCL_EXTERNAL
-sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+sycl_device_global<int32_t*> desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
 SYCL_EXTERNAL
-sycl_device_global<int32_t*> SYCL_SPACE_ATOMIC_LOCKS_NODE;
-}  // namespace Impl
-}  // namespace desul
+sycl_device_global<int32_t*> desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_NODE;
 
-namespace desul {
-namespace Impl {
+int32_t* desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+int32_t* desul::Impl::SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
-int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
-int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
-
-template <typename T>
-void init_lock_arrays_sycl(sycl::queue q) {
+template <>
+void desul::Impl::init_lock_arrays_sycl<int>(sycl::queue q) {
   if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
 
   SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h =
@@ -60,8 +53,8 @@ void init_lock_arrays_sycl(sycl::queue q) {
   q.wait_and_throw();
 }
 
-template <typename T>
-void finalize_lock_arrays_sycl(sycl::queue q) {
+template <>
+void desul::Impl::finalize_lock_arrays_sycl<int>(sycl::queue q) {
   if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h == nullptr) return;
 
   sycl::free(SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h, q);
@@ -69,10 +62,4 @@ void finalize_lock_arrays_sycl(sycl::queue q) {
   SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 }
-
-template void init_lock_arrays_sycl<int>(sycl::queue);
-template void finalize_lock_arrays_sycl<int>(sycl::queue);
-
-}  // namespace Impl
-}  // namespace desul
 #endif

--- a/atomics/src/Lock_Array_SYCL.cpp
+++ b/atomics/src/Lock_Array_SYCL.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cinttypes>
 #include <desul/atomics/Lock_Array_SYCL.hpp>
-#include <sstream>
-#include <string>
 
 namespace desul {
 namespace Impl {

--- a/atomics/src/Lock_Array_SYCL.cpp
+++ b/atomics/src/Lock_Array_SYCL.cpp
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
+#ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
+
+#include <cinttypes>
+#include <desul/atomics/Lock_Array_SYCL.hpp>
+#include <sstream>
+#include <string>
+
+namespace desul {
+namespace Impl {
+SYCL_EXTERNAL
+sycl::ext::oneapi::experimental::device_global<
+    int32_t*,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>
+    SYCL_SPACE_ATOMIC_LOCKS_DEVICE;
+SYCL_EXTERNAL
+sycl::ext::oneapi::experimental::device_global<
+    int32_t*,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>
+    SYCL_SPACE_ATOMIC_LOCKS_NODE;
+}  // namespace Impl
+}  // namespace desul
+
+namespace desul {
+namespace Impl {
+
+int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
+
+template <typename T>
+void init_lock_arrays_sycl() {
+  if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h != nullptr) return;
+
+  sycl::queue q;
+
+  SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h =
+      sycl::malloc_device<int32_t>(SYCL_SPACE_ATOMIC_MASK + 1, q);
+  SYCL_SPACE_ATOMIC_LOCKS_NODE_h =
+      sycl::malloc_host<int32_t>(SYCL_SPACE_ATOMIC_MASK + 1, q);
+
+  q.memcpy(SYCL_SPACE_ATOMIC_LOCKS_DEVICE,
+           &SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h,
+           sizeof(int32_t*));
+  q.memcpy(
+      SYCL_SPACE_ATOMIC_LOCKS_NODE, &SYCL_SPACE_ATOMIC_LOCKS_NODE_h, sizeof(int32_t*));
+
+  q.memset(SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h,
+           0,
+           sizeof(int32_t) * (SYCL_SPACE_ATOMIC_MASK + 1));
+  q.memset(SYCL_SPACE_ATOMIC_LOCKS_NODE_h,
+           0,
+           sizeof(int32_t) * (SYCL_SPACE_ATOMIC_MASK + 1));
+
+  q.wait_and_throw();
+}
+
+template <typename T>
+void finalize_lock_arrays_sycl() {
+  if (SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h == nullptr) return;
+
+  sycl::queue q;
+  sycl::free(SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h, q);
+  sycl::free(SYCL_SPACE_ATOMIC_LOCKS_NODE_h, q);
+  SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+  SYCL_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
+}
+
+template void init_lock_arrays_sycl<int>();
+template void finalize_lock_arrays_sycl<int>();
+
+}  // namespace Impl
+}  // namespace desul
+#endif


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/5613.
The feature is described in https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_global.asciidoc and an extension proposed by `Intel` to the `SYCL` standard.

The feature macro is not yet implemented in the compiler, also see https://github.com/intel/llvm/pull/7340, and there are some caveats in using it (like requiring `device_image_scope`). In any case, at least the `Kokkos` unit tests work on the relevant testbeds.

The implementation here very much follows the RDC one for CUDA/HIP. For SYCL, there is no explicit compiler flag for RDC, but device functions that are called from a different translation unit must be marked with `SYCL_EXTERNAL`. Hence, there is no need to implement two different versions (and the one using `static` variables ran into some compiler/toolchain bugs).

A minor detail is that we are currently only using the `SYCL` atomics in device functions but the global variables must be visible in both compiler passes. This is somewhat hidden by using `DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED` as a guard instead of `DESUL_HAVE_SYCL_ATOMICS`.
In this pull request, it is necessary to explicitly/manually define `DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED`. There is no autodetection here but the `Kokkos` pull request has a configuration check that would set this preprocessor macro. It's up for discussion if that's something we want in this repository as well.