### PR TITLE
SYCL: Implement generic atomis

### DIFF
--- a/atomics/include/desul/atomics/Adapt_SYCL.hpp
+++ b/atomics/include/desul/atomics/Adapt_SYCL.hpp
@@ -49,12 +49,12 @@ struct SYCLMemoryOrder<MemoryOrderSeqCst, extended_namespace> {
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderAcquire, extended_namespace> {
   static constexpr sycl_memory_order<extended_namespace> value =
-      sycl_memory_order<extended_namespace>::acquire;
+      sycl_memory_order<extended_namespace>::acq_rel;
 };
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderRelease, extended_namespace> {
   static constexpr sycl_memory_order<extended_namespace> value =
-      sycl_memory_order<extended_namespace>::release;
+      sycl_memory_order<extended_namespace>::acq_rel;
 };
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderAcqRel, extended_namespace> {


### PR DESCRIPTION
kokkos/kokkos#5105 broke my SYCL builds uncovering invalid defaults for `sycl::atomic_ref`, see https://github.com/intel/llvm/blob/894ce25635c5ead4d1c42e70f66d1970c86a7bf5/sycl/include/sycl/atomic_ref.hpp#L125-L128=:
```
static_assert(
      detail::IsValidDefaultOrder<DefaultOrder>::value,
      "Invalid default memory_order for atomics.  Valid defaults are: "
      "relaxed, acq_rel, seq_cst");
```