### PR TITLE
Fix CUDA lock arrays using inline static

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -134,7 +134,7 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 #ifdef __CUDACC_RDC__
 inline
 #else
-static
+inline static
 #endif
     void
     copy_cuda_lock_arrays_to_device() {


### PR DESCRIPTION
Alternative to #80. Corresponding to https://github.com/kokkos/kokkos/pull/5709. Pending someone else confirming that this also fixes the issue.