### PR TITLE
Cleanup unnecessary macro guard checking for `__CUDA_ARCH__`

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -138,7 +138,6 @@ __device__ std::enable_if_t<sizeof(T) == 4 || sizeof(T) == 8, T> device_atomic_e
 
 // SeqCst is not directly supported by PTX, need the additional fences:
 
-#if defined(__CUDA_ARCH__) || !defined(__NVCC__)
 namespace desul {
 namespace Impl {
 template <class T, class MemoryScope>
@@ -240,6 +239,5 @@ device_atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
 }
 }  // namespace Impl
 }  // namespace desul
-#endif
 
 #endif

--- a/atomics/include/desul/atomics/cuda/CUDA_asm.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm.hpp
@@ -1,7 +1,6 @@
 #include <limits>
 namespace desul {
 namespace Impl {
-#if defined(__CUDA_ARCH__) || (defined(__clang__) && !defined(__NVCC__))
 // Choose the variant of atomics we are using later
 #if !defined(DESUL_IMPL_ATOMIC_CUDA_PTX_PREDICATE) && \
     !defined(DESUL_IMPL_ATOMIC_CUDA_PTX_ISGLOBAL)
@@ -14,6 +13,5 @@ namespace Impl {
 #endif
 #include <desul/atomics/cuda/cuda_cc7_asm.inc>
 
-#endif
 }  // namespace Impl
 }  // namespace desul


### PR DESCRIPTION
Corresponding to kokkos/kokkos#5757