### PR TITLE
Configure atomics library based what the user enabled

### DIFF
--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -22,7 +22,7 @@ if(ENABLE_HIP)
   set(SOURCES_ARG ${DESUL_HIP_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON hip)
 endif()
-option(ENABLE_SYCL "Enable CUDA support" OFF) # option does not actually yet exist on the BLT side
+option(ENABLE_SYCL "Enable SYCL support" OFF) # option does not actually yet exist on the BLT side
 if(ENABLE_SYCL)
   set(DESUL_ATOMICS_ENABLE_SYCL ON)
 endif()

--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -22,7 +22,8 @@ if(ENABLE_HIP)
   set(SOURCES_ARG ${DESUL_HIP_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON hip)
 endif()
-if(ENABLE_SYCL) # option does not actually yet exist on the BLT side
+option(ENABLE_SYCL "Enable CUDA support" OFF) # option does not actually yet exist on the BLT side
+if(ENABLE_SYCL)
   set(DESUL_ATOMICS_ENABLE_SYCL ON)
 endif()
 if(ENABLE_OPENMP)

--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -11,15 +11,26 @@ ENDMACRO()
 
 # APPEND_GLOB(DESUL_ATOMIC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 if(ENABLE_CUDA)
+  set(DESUL_ATOMICS_ENABLE_CUDA ON)
   set(DESUL_CUDA_ATOMICS_SOURCES src/Lock_Array_CUDA.cpp)
   set(SOURCES_ARG ${DESUL_CUDA_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON cuda)
 endif()
 if(ENABLE_HIP)
+  set(DESUL_ATOMICS_ENABLE_HIP ON)
   set(DESUL_HIP_ATOMICS_SOURCES src/Lock_Array_HIP.cpp)
   set(SOURCES_ARG ${DESUL_HIP_ATOMICS_SOURCES})
   set(DEPENDS_ARG DEPENDS_ON hip)
 endif()
+if(ENABLE_SYCL) # option does not actually yet exist on the BLT side
+  set(DESUL_ATOMICS_ENABLE_SYCL ON)
+endif()
+if(ENABLE_OPENMP)
+  set(DESUL_ATOMICS_ENABLE_OPENMP ON)
+endif()
+configure_file(
+  ${PROJECT_SOURCE_DIR}/atomics/Config.hpp.cmake.in
+  ${PROJECT_BINARY_DIR}/include/desul/atomics/Config.hpp)
 
 set(INCLUDES_ARG
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -66,7 +77,9 @@ install(TARGETS desul_atomics
 install(EXPORT desul_atomics
   DESTINATION lib/cmake/desul)
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/atomics/include/
+install(DIRECTORY
+  ${PROJECT_SOURCE_DIR}/atomics/include/
+  ${PROJECT_BINARY_DIR}/include
   DESTINATION include
   FILES_MATCHING
   PATTERN *.hpp

--- a/atomics/Config.hpp.cmake.in
+++ b/atomics/Config.hpp.cmake.in
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_CONFIG_HPP_
+#define DESUL_ATOMICS_CONFIG_HPP_
+
+#cmakedefine DESUL_ATOMICS_ENABLE_CUDA
+#cmakedefine DESUL_ATOMICS_ENABLE_HIP
+#cmakedefine DESUL_ATOMICS_ENABLE_SYCL
+#cmakedefine DESUL_ATOMICS_ENABLE_OPENMP
+
+#endif

--- a/atomics/desul_atomicsConfig.cmake.in
+++ b/atomics/desul_atomicsConfig.cmake.in
@@ -6,3 +6,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/desul_atomics.cmake")
 # check_required_components("@PROJECT_NAME@")
 check_required_components("desul_atomics")
 
+set(desul_atomics_ENABLE_CUDA   @ENABLE_CUDA@)
+set(desul_atomics_ENABLE_HIP    @ENABLE_HIP@)
+set(desul_atomics_ENABLE_SYCL   @ENABLE_SYCL@)
+set(desul_atomics_ENABLE_OPENMP @ENABLE_OPENMP@)
+

--- a/atomics/include/desul/atomics/Macros.hpp
+++ b/atomics/include/desul/atomics/Macros.hpp
@@ -9,7 +9,25 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_MACROS_HPP_
 #define DESUL_ATOMICS_MACROS_HPP_
 
+#include <desul/atomics/Config.hpp>
+
 // Macros
+
+#if defined(DESUL_ATOMICS_ENABLE_CUDA) && defined(__CUDACC__)
+#define DESUL_HAVE_CUDA_ATOMICS
+#endif
+
+#if defined(DESUL_ATOMICS_ENABLE_HIP) && defined(__HIPCC__)
+#define DESUL_HAVE_HIP_ATOMICS
+#endif
+
+#if defined(DESUL_ATOMICS_ENABLE_SYCL) && defined(SYCL_LANGUAGE_VERSION)
+#define DESUL_HAVE_SYCL_ATOMICS
+#endif
+
+#if defined(DESUL_ATOMICS_ENABLE_OPENMP)
+#define DESUL_HAVE_OPENMP_ATOMICS
+#endif
 
 // ONLY use GNUC atomics if not explicitly say to use OpenMP atomics
 #if !defined(DESUL_HAVE_OPENMP_ATOMICS) && defined(__GNUC__)
@@ -21,20 +39,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_HAVE_MSVC_ATOMICS
 #endif
 
-#ifdef __CUDACC__
-#define DESUL_HAVE_CUDA_ATOMICS
-#endif
-
-#ifdef __HIPCC__
-#define DESUL_HAVE_HIP_ATOMICS
-#endif
-
-#ifdef SYCL_LANGUAGE_VERSION
-#define DESUL_HAVE_SYCL_ATOMICS
-#endif
-
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
-    defined(__SYCL_DEVICE_ONLY__)
+#if (defined(DESUL_ATOMICS_ENABLE_CUDA) && defined(__CUDA_ARCH__)) ||         \
+    (defined(DESUL_ATOMICS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)) || \
+    (defined(DESUL_ATOMICS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
 #define DESUL_HAVE_GPU_LIKE_PROGRESS
 #endif
 
@@ -62,7 +69,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_IMPL_ESC_(...) DESUL_IMPL_VAN_##__VA_ARGS__
 #define DESUL_IMPL_VAN_DESUL_IMPL_ISH
 
-#if defined(__CUDACC__) && defined(__NVCOMPILER)
+#if (defined(DESUL_ATOMICS_ENABLE_CUDA) && defined(__CUDACC__)) && defined(__NVCOMPILER)
 #include <nv/target>
 #define DESUL_IF_ON_DEVICE(CODE) NV_IF_TARGET(NV_IS_DEVICE, CODE)
 #define DESUL_IF_ON_HOST(CODE) NV_IF_TARGET(NV_IS_HOST, CODE)
@@ -99,8 +106,9 @@ static constexpr bool desul_impl_omp_on_host() { return false; }
 #endif
 
 #if !defined(DESUL_IF_ON_HOST) && !defined(DESUL_IF_ON_DEVICE)
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
-    defined(__SYCL_DEVICE_ONLY__)
+#if (defined(DESUL_ATOMICS_ENABLE_CUDA) && defined(__CUDA_ARCH__)) ||         \
+    (defined(DESUL_ATOMICS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)) || \
+    (defined(DESUL_ATOMICS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
 #define DESUL_IF_ON_DEVICE(CODE) \
   { DESUL_IMPL_STRIP_PARENS(CODE) }
 #define DESUL_IF_ON_HOST(CODE) \


### PR DESCRIPTION
Corresponding to kokkos/kokkos#5764
Essentially required to support building and using Kokkos with `nvcc_wrapper` but CUDA disabled.  Don't ask me why would one ever want to do that, we just have users who do that and we (reluctantly) agreed we'd support it.