### PR TITLE
Make building tests optional

### DIFF
--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -87,5 +87,7 @@ install(DIRECTORY
   PATTERN *.inc
   PATTERN *.inc_*)
 
-add_subdirectory(unit_tests)
-add_subdirectory(performance_tests)
+if(BUILD_TESTING)
+  add_subdirectory(unit_tests)
+  add_subdirectory(performance_tests)
+endif()


### PR DESCRIPTION
Currently, it's not possible to configure `desul` without configuring tests (which requires `Kokkos`) although there is a `CMake` option that should control it.