### PR TITLE
Replace HIP_LOCK_ARRAYS macros by functions

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array.hpp
+++ b/atomics/include/desul/atomics/Lock_Array.hpp
@@ -67,7 +67,7 @@ inline void ensure_lock_arrays_on_device() {
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+  ensure_hip_lock_arrays_on_device();
 #endif
 }
 

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -35,7 +35,7 @@ extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 template <typename /*AlwaysInt*/ = int>
 void init_lock_arrays_hip();
 
-/// \brief After this call, the g_host_cuda_lock_arrays variable has
+/// \brief After this call, the g_host_hip_lock_arrays variable has
 ///        all null pointers, and all array memory has been freed.
 ///
 /// This call is idempotent.
@@ -64,10 +64,10 @@ namespace Impl {
  * be created in every translation unit that sees this header file (we make this
  * clear by marking it static, meaning no other translation unit can link to
  * it). Since the Kokkos_HIP_Locks.cpp translation unit cannot initialize the
- * instances in other translation units, we must update this CUDA global
+ * instances in other translation units, we must update this HIP global
  * variable based on the Host global variable prior to running any kernels that
  * will use it.  That is the purpose of the
- * KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE macro.
+ * ensure_hip_lock_arrays_on_device function.
  */
 __device__
 #ifdef DESUL_HIP_RDC
@@ -133,31 +133,34 @@ namespace {
 static int lock_array_copied = 0;
 inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
-}  // namespace Impl
-}  // namespace desul
 
-/* It is critical that this code be a macro, so that it will
-   capture the right address for g_device_hip_lock_arrays!
-   putting this in an inline function will NOT do the right thing! */
-#define DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                                   \
-  {                                                                                   \
-    if (::desul::Impl::lock_array_copied == 0) {                                      \
-      (void)hipMemcpyToSymbol(                                                        \
-          HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE),                   \
-          &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,                            \
-          sizeof(int32_t*));                                                          \
-      (void)hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE), \
-                              &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE_h,          \
-                              sizeof(int32_t*));                                      \
-    }                                                                                 \
-    ::desul::Impl::lock_array_copied = 1;                                             \
+#ifdef DESUL_HIP_RDC
+inline
+#else
+inline static
+#endif
+    void
+    copy_hip_lock_arrays_to_device() {
+  if (lock_array_copied == 0) {
+    (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_DEVICE),
+                            &HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
+                            sizeof(int32_t*));
+    (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_NODE),
+                            &HIP_SPACE_ATOMIC_LOCKS_NODE_h,
+                            sizeof(int32_t*));
   }
+  lock_array_copied = 1;
+}
+}  // namespace Impl
 
 #if defined(DESUL_HIP_RDC) || (!defined(__HIPCC__))
-#define DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE()
+inline void ensure_hip_lock_arrays_on_device() {}
 #else
-#define DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE() \
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()
+static inline void ensure_hip_lock_arrays_on_device() {
+  Impl::copy_hip_lock_arrays_to_device();
+}
 #endif
+
+}  // namespace desul
 
 #endif

--- a/atomics/performance_tests/kokkos_based/UnitTestMainInit.cpp
+++ b/atomics/performance_tests/kokkos_based/UnitTestMainInit.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_hip_lock_arrays_on_device();
 #endif
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/atomics/src/Lock_Array_HIP.cpp
+++ b/atomics/src/Lock_Array_HIP.cpp
@@ -70,7 +70,7 @@ void init_lock_arrays_hip() {
                             "init_lock_arrays_hip: hipMallocHost host locks");
 
   auto error_sync1 = hipDeviceSynchronize();
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
   check_error_and_throw_hip(error_sync1, "init_lock_arrays_hip: post malloc");
 
   init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
@@ -89,7 +89,7 @@ void finalize_lock_arrays_hip() {
   HIP_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   HIP_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 #ifdef DESUL_HIP_RDC
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
 #endif
 }
 

--- a/atomics/unit_tests/kokkos_based/UnitTestMainInit.cpp
+++ b/atomics/unit_tests/kokkos_based/UnitTestMainInit.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_hip_lock_arrays_on_device();
 #endif
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Corresponding to https://github.com/kokkos/kokkos/pull/5770. Analogous to https://github.com/desul/desul/pull/64.