### PR TITLE
Test with Kokkos >=4.0.0 commit instead of 3.4.01

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -33,9 +33,15 @@ jobs:
         run: |
           git submodule init
           git submodule update
-      - name: Install Kokkos
+     - name: Checkout Kokkos
+        uses: actions/checkout@v2.2.0
+        with:
+          repository: kokkos/kokkos
+          # FIXME Use 4.0.00 or later when released
+          ref: b5bd709fd615a0a5bc78492f171307bdafa2f53a
+          path: kokkos_src
+     - name: Install Kokkos
         run: |
-          git clone --branch 3.4.01 --single-branch --depth 1 https://github.com/kokkos/kokkos.git kokkos_src
           cd kokkos_src
           mkdir -p build
           cd build

--- a/atomics/performance_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/performance_tests/kokkos_based/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(DESUL_ENABLE_TESTS)
-find_package(Kokkos 3 REQUIRED)
+find_package(Kokkos 4 REQUIRED)
 blt_add_library(NAME kokkos_perf_test_main
                 SOURCES UnitTestMainInit.cpp
                 DEPENDS_ON desul_atomics gtest Kokkos::kokkos ${DESUL_BACKENDS})

--- a/atomics/unit_tests/kokkos_based/CMakeLists.txt
+++ b/atomics/unit_tests/kokkos_based/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(DESUL_ENABLE_TESTS)
-find_package(Kokkos 3 REQUIRED)
+find_package(Kokkos 4 REQUIRED)
 
 # Make sure that Kokkos was built with the requested backends
 foreach(BACKEND ${DESUL_BACKENDS})

--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -814,9 +814,7 @@ bool DivAtomicTest(T i0, T i1) {
 
   bool passed = true;
 
-  using Kokkos::abs;
-  using std::abs;
-  if (abs((resSerial - res) * 1.) > 1e-5) {
+  if (Kokkos::abs((resSerial - res) * 1.) > 1e-5) {
     passed = false;
 
     std::cout << "Loop<" << typeid(T).name() << ">( test = DivAtomicTest"


### PR DESCRIPTION
The update in the fedora CI containers used for unit tests broke CI. Since the fix is only in develop, I decided to use commit on `develop` for the moment and require `Kokkos` >= 4.0.0.0 in general. Related to #88.