### PR TITLE
Fix CI (indentation mistake caused it to not run)

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -33,14 +33,14 @@ jobs:
         run: |
           git submodule init
           git submodule update
-     - name: Checkout Kokkos
+      - name: Checkout Kokkos
         uses: actions/checkout@v2.2.0
         with:
           repository: kokkos/kokkos
           # FIXME Use 4.0.00 or later when released
           ref: b5bd709fd615a0a5bc78492f171307bdafa2f53a
           path: kokkos_src
-     - name: Install Kokkos
+      - name: Install Kokkos
         run: |
           cd kokkos_src
           mkdir -p build


### PR DESCRIPTION
I merged #90 a bit hastily and did not realize only clang-format had run