### PR TITLE
Drop (unused) `Impl::eliminate_warning_for_lock_array` CUDA/HIP functions

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -128,7 +128,6 @@ namespace desul {
 namespace Impl {
 namespace {
 static int lock_array_copied = 0;
-inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
 
 #ifdef __CUDACC_RDC__

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -131,7 +131,6 @@ namespace desul {
 namespace Impl {
 namespace {
 static int lock_array_copied = 0;
-inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
 }  // namespace Impl
 }  // namespace desul


### PR DESCRIPTION
Not able to re-open #89, sorry about the noise