### PR TITLE
Let device lock array ptrs be in constant memory regardless of whether RDC is enabled or not

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -69,17 +69,15 @@ namespace Impl {
 /// variable based on the Host global variable prior to running any kernels
 /// that will use it.
 /// That is the purpose of the ensure_cuda_lock_arrays_on_device function.
-__device__
 #ifdef __CUDACC_RDC__
-    __constant__ extern
+extern
 #endif
-    int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
+    __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
 
-__device__
 #ifdef __CUDACC_RDC__
-    __constant__ extern
+extern
 #endif
-    int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
+    __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
 
 #define CUDA_SPACE_ATOMIC_MASK 0x1FFFF
 

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -69,17 +69,15 @@ namespace Impl {
  * will use it.  That is the purpose of the
  * ensure_hip_lock_arrays_on_device function.
  */
-__device__
 #ifdef DESUL_HIP_RDC
-    __constant__ extern
+extern
 #endif
-    int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
+    __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
 
-__device__
 #ifdef DESUL_HIP_RDC
-    __constant__ extern
+extern
 #endif
-    int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
+    __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
 
 #define HIP_SPACE_ATOMIC_MASK 0x1FFFF
 


### PR DESCRIPTION
Was in constant memory only when relocatable device code is enabled.

Corresponding to https://github.com/kokkos/kokkos/pull/5825