### PR TITLE
Cleanup lock array macro guards

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -45,8 +45,6 @@ void finalize_lock_arrays_cuda();
 }  // namespace Impl
 }  // namespace desul
 
-#if defined(__CUDACC__)
-
 namespace desul {
 namespace Impl {
 
@@ -149,13 +147,11 @@ inline static
 }  // namespace Impl
 }  // namespace desul
 
-#endif /* defined( __CUDACC__ ) */
-
 #endif /* defined( DESUL_HAVE_CUDA_ATOMICS ) */
 
 namespace desul {
 
-#if defined(__CUDACC_RDC__) || (!defined(__CUDACC__))
+#if defined(__CUDACC_RDC__)
 inline void ensure_cuda_lock_arrays_on_device() {}
 #else
 static inline void ensure_cuda_lock_arrays_on_device() {

--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -42,12 +42,6 @@ void init_lock_arrays_cuda();
 template <typename /*AlwaysInt*/ = int>
 void finalize_lock_arrays_cuda();
 
-}  // namespace Impl
-}  // namespace desul
-
-namespace desul {
-namespace Impl {
-
 /// \brief This global variable in CUDA space is what kernels use
 ///        to get access to the lock arrays.
 ///
@@ -116,12 +110,7 @@ __device__ inline void unlock_address_cuda(void* ptr, desul::MemoryScopeNode) {
   atomicExch(&desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE[offset], 0);
 }
 
-}  // namespace Impl
-}  // namespace desul
-
 // Make lock_array_copied an explicit translation unit scope thingy
-namespace desul {
-namespace Impl {
 namespace {
 static int lock_array_copied = 0;
 }  // namespace

--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -9,12 +9,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 #define DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 
+#include <cstdint>
+
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
-
-#ifdef DESUL_HAVE_CUDA_ATOMICS
-
-#include <cstdint>
 
 namespace desul {
 namespace Impl {
@@ -135,8 +133,6 @@ inline static
 
 }  // namespace Impl
 }  // namespace desul
-
-#endif /* defined( DESUL_HAVE_CUDA_ATOMICS ) */
 
 namespace desul {
 

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -46,7 +46,6 @@ void finalize_lock_arrays_hip();
 }  // namespace Impl
 }  // namespace desul
 
-#ifdef __HIPCC__
 namespace desul {
 namespace Impl {
 
@@ -120,7 +119,7 @@ __device__ inline void unlock_address_hip(void* ptr, desul::MemoryScopeNode) {
   offset = offset & HIP_SPACE_ATOMIC_MASK;
   atomicExch(&desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE[offset], 0);
 }
-#endif
+
 }  // namespace Impl
 }  // namespace desul
 
@@ -150,7 +149,7 @@ inline static
 }
 }  // namespace Impl
 
-#if defined(DESUL_HIP_RDC) || (!defined(__HIPCC__))
+#if defined(DESUL_HIP_RDC)
 inline void ensure_hip_lock_arrays_on_device() {}
 #else
 static inline void ensure_hip_lock_arrays_on_device() {

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -43,11 +43,6 @@ void init_lock_arrays_hip();
 ///   snapshotted version while also linking against pure Desul
 template <typename /*AlwaysInt*/ = int>
 void finalize_lock_arrays_hip();
-}  // namespace Impl
-}  // namespace desul
-
-namespace desul {
-namespace Impl {
 
 /**
  * \brief This global variable in HIP space is what kernels use to get access
@@ -120,12 +115,7 @@ __device__ inline void unlock_address_hip(void* ptr, desul::MemoryScopeNode) {
   atomicExch(&desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE[offset], 0);
 }
 
-}  // namespace Impl
-}  // namespace desul
-
 // Make lock_array_copied an explicit translation unit scope thing
-namespace desul {
-namespace Impl {
 namespace {
 static int lock_array_copied = 0;
 }  // namespace

--- a/atomics/src/Lock_Array_CUDA.cpp
+++ b/atomics/src/Lock_Array_CUDA.cpp
@@ -11,7 +11,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#ifdef DESUL_HAVE_CUDA_ATOMICS
 #ifdef __CUDACC_RDC__
 namespace desul {
 namespace Impl {
@@ -96,4 +95,3 @@ template void finalize_lock_arrays_cuda<int>();
 }  // namespace Impl
 
 }  // namespace desul
-#endif

--- a/atomics/src/Lock_Array_HIP.cpp
+++ b/atomics/src/Lock_Array_HIP.cpp
@@ -11,7 +11,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#ifdef DESUL_HAVE_HIP_ATOMICS
 #ifdef DESUL_HIP_RDC
 namespace desul {
 namespace Impl {
@@ -99,4 +98,3 @@ template void finalize_lock_arrays_hip<int>();
 }  // namespace Impl
 
 }  // namespace desul
-#endif


### PR DESCRIPTION
Corresponding to kokkos/kokkos#5841

Drop unnecessary macro guards in device CUDA and HIP lock arrays that make the code hard to read