### PR TITLE
Prefer `__CLANG_RDC__` to `DESUL_HIP_RDC` macro

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -63,12 +63,12 @@ void finalize_lock_arrays_hip();
  * will use it.  That is the purpose of the
  * ensure_hip_lock_arrays_on_device function.
  */
-#ifdef DESUL_HIP_RDC
+#ifdef __CLANG_RDC__
 extern
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
 
-#ifdef DESUL_HIP_RDC
+#ifdef __CLANG_RDC__
 extern
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
@@ -120,7 +120,7 @@ namespace {
 static int lock_array_copied = 0;
 }  // namespace
 
-#ifdef DESUL_HIP_RDC
+#ifdef __CLANG_RDC__
 inline
 #else
 inline static
@@ -139,7 +139,7 @@ inline static
 }
 }  // namespace Impl
 
-#if defined(DESUL_HIP_RDC)
+#if defined(__CLANG_RDC__)
 inline void ensure_hip_lock_arrays_on_device() {}
 #else
 static inline void ensure_hip_lock_arrays_on_device() {

--- a/atomics/src/Lock_Array_HIP.cpp
+++ b/atomics/src/Lock_Array_HIP.cpp
@@ -11,7 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#ifdef DESUL_HIP_RDC
+#ifdef __CLANG_RDC__
 namespace desul {
 namespace Impl {
 __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE = nullptr;
@@ -87,7 +87,7 @@ void finalize_lock_arrays_hip() {
   check_error_and_throw_hip(error_free2, "finalize_lock_arrays_hip: free host locks");
   HIP_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   HIP_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
-#ifdef DESUL_HIP_RDC
+#ifdef __CLANG_RDC__
   copy_hip_lock_arrays_to_device();
 #endif
 }


### PR DESCRIPTION
Correspond to kokkos/kokkos#5947
The macro is defined for all ROCm versions we support.