### PR TITLE
Fix warning with NVC++

### DIFF
--- a/atomics/include/desul/atomics/Common.hpp
+++ b/atomics/include/desul/atomics/Common.hpp
@@ -83,11 +83,11 @@ struct numeric_limits_max;
 
 template <>
 struct numeric_limits_max<uint32_t> {
-  static constexpr uint32_t value = -1;
+  static constexpr auto value = static_cast<uint32_t>(-1);
 };
 template <>
 struct numeric_limits_max<uint64_t> {
-  static constexpr uint64_t value = -1;
+  static constexpr auto value = static_cast<uint64_t>(-1);
 };
 
 constexpr bool atomic_always_lock_free(std::size_t size) {


### PR DESCRIPTION
Fixup for #99
Getting warnings with NVC++ from NVHPC SDK 23.1
```
"<desul>/include/desul/atomics/Common.hpp", line 86: warning: integer conversion resulted in a change of sign [integer_sign_change]
    static constexpr uint32_t value = -1;
```
                                      ^