### PR TITLE
Fix for OpenMP atomics with nvhpc.

### DIFF
--- a/atomics/include/desul/atomics/Thread_Fence_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Thread_Fence_OpenMP.hpp
@@ -16,7 +16,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
-#if _OPENMP > 201800
+// NVHPC compiler only supports the basic flush construct without the memory-order-clause.
+#if _OPENMP > 201800 && !defined(__NVCOMPILER)
 
 // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
 inline void host_atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {

--- a/atomics/include/desul/atomics/Thread_Fence_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Thread_Fence_OpenMP.hpp
@@ -16,7 +16,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
-// NVHPC compiler only supports the basic flush construct without the memory-order-clause.
+// NVHPC compiler only supports the basic flush construct without the
+// memory-order-clause.
 #if _OPENMP > 201800 && !defined(__NVCOMPILER)
 
 // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?


### PR DESCRIPTION
The PR avoids the use of `memory-order-clause` with the `flush` construct when using OpenMP with NVHPC compiler. 