### PR TITLE
Fix CUDA ptx for atomic max/min of int64_t

### DIFF
--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_isglobal
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_isglobal
@@ -164,38 +164,55 @@ inline __device__ ctype device_atomic_fetch_dec_mod(ctype* dest, ctype limit, __
   return result; \
 }
 
-// Group ops for integer ctypes
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(ctype,asm_ctype,reg_ctype,reg_ret_ctype)
-
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(ctype,asm_ctype,reg_ctype,reg_ret_ctype)
-
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP() \
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_AND() \
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_OR() \
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_XOR()
 
-
 // Instantiate Functions
+
+// General comments:
+//  - float/double only support add
+//  - inc/dec only supported with uint32_t
+//  - int64_t does not support add
+
+// floating point types
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(float,".f32","f","=f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(float,".f32","f","=f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(double,".f64","d","=d")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(double,".f64","d","=d")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(uint32_t,".u32","r","=r")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(uint64_t,".u64","l","=l")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(int32_t,".s32","r","=r")
-//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(int64_t,".s64","l","=l")
-
+// uint32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(uint32_t,".u32","r","=r")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(uint32_t,".u32","r","=r")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(uint32_t,".u32","r","=r")
+
+// uint64_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(uint64_t,".u64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(uint64_t,".u64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(uint64_t,".u64","l","=l")
+
+// int32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(int32_t,".s32","r","=r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(int32_t,".s32","r","=r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(int32_t,".s32","r","=r")
+
+// int64_t note: add/sub is using unsigned register
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(int64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(int64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(int64_t,".s64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(int64_t,".s64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(int64_t,".s64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(int64_t,".s64","l","=l")
 
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP()
 
@@ -205,4 +222,4 @@ __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP()
 #undef __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC
 #undef __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC
 #undef __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_AND
-
+#undef __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_predicate
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_predicate
@@ -206,19 +206,6 @@ inline __device__ ctype device_atomic_fetch_dec_mod(ctype* dest, ctype limit, __
   return result; \
 }
 
-// Group ops for integer ctypes
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(ctype,asm_ctype,reg_ctype,reg_ret_ctype)
-
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(ctype,asm_ctype,reg_ctype,reg_ret_ctype) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(ctype,asm_ctype,reg_ctype,reg_ret_ctype)
-
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP() \
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_AND() \
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_OR() \
@@ -226,18 +213,49 @@ __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_XOR()
 
 
 // Instantiate Functions
+
+// General comments:
+//  - float/double only support add
+//  - inc/dec only supported with uint32_t
+//  - int64_t does not support add
+
+// floating point types
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(float,".f32","f","=f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(float,".f32","f","=f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(double,".f64","d","=d")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(double,".f64","d","=d")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(uint32_t,".u32","r","=r")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_UNSIGNED_OP(uint64_t,".u64","l","=l")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(int32_t,".s32","r","=r")
-//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INTEGER_OP(int64_t,".s64","l","=l")
-
+// uint32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(uint32_t,".u32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(uint32_t,".u32","r","=r")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(uint32_t,".u32","r","=r")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(uint32_t,".u32","r","=r")
+
+// uint64_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(uint64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(uint64_t,".u64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(uint64_t,".u64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(uint64_t,".u64","l","=l")
+
+// int32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(int32_t,".s32","r","=r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(int32_t,".s32","r","=r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(int32_t,".s32","r","=r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(int32_t,".s32","r","=r")
+
+// int64_t note: add/sub is using unsigned register
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_ADD(int64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_SUB(int64_t,".u64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MIN(int64_t,".s64","l","=l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_MAX(int64_t,".s64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_INC(int64_t,".s64","l","=l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_DEC(int64_t,".s64","l","=l")
 
 __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_BIN_OP()
 

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_op.inc_isglobal
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_op.inc_isglobal
@@ -60,29 +60,48 @@ inline __device__ void device_atomic_dec(type* dest, __DESUL_IMPL_CUDA_ASM_MEMOR
   } \
 }
 
-// Group ops for integer types
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(type,asm_type,reg_type)
-
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_UNSIGNED_OP(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(type,asm_type,reg_type)
-
 // Instantiate Functions
+
+// General comments:
+//  - float/double only support add
+//  - inc/dec only supported with uint32_t
+//  - int64_t does not support add
+
+// floating point types
 __DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(float,".f32","f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(float,".f32","f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(double,".f64","d")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(double,".f64","d")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_UNSIGNED_OP(uint32_t,".u32","r")
+// uint32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(uint32_t,".u32","r")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int64_t,".u64","l")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int32_t,".s32","r")
-//__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int64_t,".s64","l")
+// uint64_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(uint64_t,".u64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(uint64_t,".u64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(uint64_t,".u64","l")
+
+// int32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(int32_t,".s32","r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(int32_t,".s32","r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(int32_t,".s32","r")
+
+// int64_t note: add/sub is using unsigned register
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(int64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(int64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(int64_t,".s64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(int64_t,".s64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(int64_t,".s64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(int64_t,".s64","l")
+

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_op.inc_predicate
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_op.inc_predicate
@@ -78,29 +78,48 @@ inline __device__ void device_atomic_dec(type* dest, __DESUL_IMPL_CUDA_ASM_MEMOR
     :: "l"(dest),reg_type(limit) : "memory"); \
 }
 
-// Group ops for integer types
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(type,asm_type,reg_type)
-
-#define __DESUL_IMPL_CUDA_ASM_ATOMIC_UNSIGNED_OP(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(type,asm_type,reg_type) \
-__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(type,asm_type,reg_type)
-
 // Instantiate Functions
+
+// General comments:
+//  - float/double only support add
+//  - inc/dec only supported with uint32_t
+//  - int64_t does not support add
+
+// floating point types
 __DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(float,".f32","f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(float,".f32","f")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(double,".f64","d")
 __DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(double,".f64","d")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_UNSIGNED_OP(uint32_t,".u32","r")
+// uint32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(uint32_t,".u32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(uint32_t,".u32","r")
 
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int64_t,".u64","l")
-__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int32_t,".s32","r")
-//__DESUL_IMPL_CUDA_ASM_ATOMIC_INTEGER_OP(int64_t,".s64","l")
+// uint64_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(uint64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(uint64_t,".u64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(uint64_t,".u64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(uint64_t,".u64","l")
+
+// int32_t
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(int32_t,".s32","r")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(int32_t,".s32","r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(int32_t,".s32","r")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(int32_t,".s32","r")
+
+// int64_t note: add/sub are using unsigned register!
+__DESUL_IMPL_CUDA_ASM_ATOMIC_ADD(int64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_SUB(int64_t,".u64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MIN(int64_t,".s64","l")
+__DESUL_IMPL_CUDA_ASM_ATOMIC_MAX(int64_t,".s64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_INC(int64_t,".s64","l")
+//__DESUL_IMPL_CUDA_ASM_ATOMIC_DEC(int64_t,".s64","l")
+


### PR DESCRIPTION
Cleaned up the logic a bit, we still need to deal with int vs long vs long as opposed to just int32_t vs int64_t.