### PR TITLE
SYCL: Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL to detect support for sycl::device_global without sycl::device_image_scope

### DIFF
--- a/atomics/include/desul/atomics/Adapt_SYCL.hpp
+++ b/atomics/include/desul/atomics/Adapt_SYCL.hpp
@@ -88,14 +88,17 @@ using sycl_atomic_ref = sycl::atomic_ref<T,
                                          sycl::access::address_space::generic_space>;
 #endif
 
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
-// FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
+#ifdef SYCL_EXT_ONEAPI_DEVICE_GLOBAL
+template <class T>
+using sycl_device_global = sycl::ext::oneapi::experimental::device_global<T>;
+#else
 template <class T>
 using sycl_device_global = sycl::ext::oneapi::experimental::device_global<
     T,
     decltype(sycl::ext::oneapi::experimental::properties(
         sycl::ext::oneapi::experimental::device_image_scope))>;
+#endif
 #endif
 
 }  // namespace Impl


### PR DESCRIPTION
Correspsonds to https://github.com/kokkos/kokkos/pull/6531. As discussed there, this feature still doesn't work properly with shared libraries but at least we can get rid of `sycl::ext::oneapi::experimental::device_image_scope` which would force using `-fsycl-device-code-split=off` (instead of, say, `-fsycl-device-code-split=per_kernel` which helps with compilation time).