### PR TITLE
Revisit class providing atomic operations for non-atomic objects

### DIFF
--- a/atomics/include/desul/atomics/Atomic_Ref.hpp
+++ b/atomics/include/desul/atomics/Atomic_Ref.hpp
@@ -6,60 +6,21 @@ Source: https://github.com/desul/desul
 SPDX-License-Identifier: (BSD-3-Clause)
 */
 
-#ifndef DESUL_ATOMIC_REF_IMPL_HPP_
-#define DESUL_ATOMIC_REF_IMPL_HPP_
+#ifndef DESUL_ATOMIC_REF_HPP_
+#define DESUL_ATOMIC_REF_HPP_
 
-#include <cstddef>
 #include <desul/atomics/Common.hpp>
 #include <desul/atomics/Generic.hpp>
 #include <desul/atomics/Macros.hpp>
-#include <memory>
-#include <type_traits>
 
 namespace desul {
-namespace Impl {
 
-// TODO current implementation is missing the following:
-// * member functions
-//   * wait
-//   * notify_one
-//   * notify_all
-
-template <typename T,
-          typename MemoryOrder,
-          typename MemoryScope,
-          bool = std::is_integral<T>{},
-          bool = std::is_floating_point<T>{}>
-struct basic_atomic_ref;
-
-// base class for non-integral, non-floating-point, non-pointer types
 template <typename T, typename MemoryOrder, typename MemoryScope>
-struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
-  static_assert(std::is_trivially_copyable<T>{}, "");
-
- private:
-  T* _ptr;
-
-  // 1/2/4/8/16-byte types must be aligned to at least their size
-  static constexpr int _min_alignment = (sizeof(T) & (sizeof(T) - 1)) || sizeof(T) > 16
-                                            ? 0
-                                            : sizeof(T);
+class AtomicRef {
+  T* ptr_;
 
  public:
-  using value_type = T;
-
-  static constexpr bool is_always_lock_free = atomic_always_lock_free(sizeof(T));
-
-  static constexpr std::size_t required_alignment = _min_alignment > alignof(T)
-                                                        ? _min_alignment
-                                                        : alignof(T);
-
-  basic_atomic_ref() = delete;
-  basic_atomic_ref& operator=(basic_atomic_ref const&) = delete;
-
-  basic_atomic_ref(basic_atomic_ref const&) = default;
-
-  explicit basic_atomic_ref(T& obj) : _ptr(std::addressof(obj)) {}
+  explicit AtomicRef(T& obj) : ptr_(&obj) {}
 
   T operator=(T desired) const noexcept {
     this->store(desired);
@@ -68,471 +29,65 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
 
   operator T() const noexcept { return this->load(); }
 
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION void store(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    atomic_store(_ptr, desired, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T load(_MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T exchange(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, desired, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION bool is_lock_free() const noexcept {
-    return atomic_is_lock_free<sizeof(T), required_alignment>();
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(T& expected,
-                                            T desired,
-                                            SuccessMemoryOrder success,
-                                            FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_weak(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_weak(expected,
-                                 desired,
-                                 order,
-                                 cmpexch_failure_memory_order<_MemoryOrder>(),
-                                 MemoryScope());
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected,
-      T desired,
-      SuccessMemoryOrder success,
-      FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_strong(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_strong(expected,
-                                   desired,
-                                   order,
-                                   cmpexch_failure_memory_order<_MemoryOrder>(),
-                                   MemoryScope());
-  }
-};
-
-// base class for atomic_ref<integral-type>
-template <typename T, typename MemoryOrder, typename MemoryScope>
-struct basic_atomic_ref<T, MemoryOrder, MemoryScope, true, false> {
-  static_assert(std::is_integral<T>{}, "");
-
- private:
-  T* _ptr;
-
- public:
   using value_type = T;
-  using difference_type = value_type;
 
-  static constexpr bool is_always_lock_free = atomic_always_lock_free(sizeof(T));
-
-  static constexpr std::size_t required_alignment = sizeof(T) > alignof(T) ? sizeof(T)
-                                                                           : alignof(T);
-
-  basic_atomic_ref() = delete;
-  basic_atomic_ref& operator=(basic_atomic_ref const&) = delete;
-
-  explicit basic_atomic_ref(T& obj) : _ptr(&obj) {}
-
-  basic_atomic_ref(basic_atomic_ref const&) = default;
-
-  T operator=(T desired) const noexcept {
-    this->store(desired);
-    return desired;
+  DESUL_FUNCTION T load() const noexcept {
+    return desul::atomic_load(ptr_, MemoryOrder(), MemoryScope());
+  }
+  DESUL_FUNCTION void store(T val) const noexcept {
+    return desul::atomic_store(ptr_, val, MemoryOrder(), MemoryScope());
   }
 
-  operator T() const noexcept { return this->load(); }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION void store(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    atomic_store(_ptr, desired, order, MemoryScope());
+#define DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(OP)                                   \
+  DESUL_FUNCTION T fetch_##OP(T val) const noexcept {                           \
+    return desul::atomic_fetch_##OP(ptr_, val, MemoryOrder(), MemoryScope());   \
+  }                                                                             \
+  DESUL_FUNCTION T OP##_fetch(T val) const noexcept {                           \
+    return desul::atomic_##OP##_fetch(ptr_, val, MemoryOrder(), MemoryScope()); \
   }
 
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T load(_MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, order, MemoryScope());
+#define DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(COMPD_ASGMT, OP) \
+  DESUL_FUNCTION T operator COMPD_ASGMT(T arg) const noexcept {          \
+    return OP##_fetch(arg);                                              \
   }
 
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T exchange(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, desired, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION bool is_lock_free() const noexcept {
-    return atomic_is_lock_free<sizeof(T), required_alignment>();
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(T& expected,
-                                            T desired,
-                                            SuccessMemoryOrder success,
-                                            FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_weak(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_weak(expected,
-                                 desired,
-                                 order,
-                                 cmpexch_failure_memory_order<_MemoryOrder>(),
-                                 MemoryScope());
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected,
-      T desired,
-      SuccessMemoryOrder success,
-      FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_strong(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_strong(expected,
-                                   desired,
-                                   order,
-                                   cmpexch_failure_memory_order<_MemoryOrder>(),
-                                   MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_add(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_add(_ptr, arg, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_sub(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_sub(_ptr, arg, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_and(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_and(_ptr, arg, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_or(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_or(_ptr, arg, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_xor(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_xor(_ptr, arg, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator++() const noexcept {
-    return atomic_add_fetch(_ptr, value_type(1), MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator++(int) const noexcept { return fetch_add(1); }
-
-  DESUL_FUNCTION value_type operator--() const noexcept {
-    return atomic_sub_fetch(_ptr, value_type(1), MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator--(int) const noexcept { return fetch_sub(1); }
-
-  DESUL_FUNCTION value_type operator+=(value_type arg) const noexcept {
-    return atomic_add_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator-=(value_type arg) const noexcept {
-    return atomic_sub_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator&=(value_type arg) const noexcept {
-    return atomic_and_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator|=(value_type arg) const noexcept {
-    return atomic_or_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator^=(value_type arg) const noexcept {
-    return atomic_xor_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-};
-
-// base class for atomic_ref<floating-point-type>
-template <typename T, typename MemoryOrder, typename MemoryScope>
-struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, true> {
-  static_assert(std::is_floating_point<T>{}, "");
-
- private:
-  T* _ptr;
-
- public:
-  using value_type = T;
-  using difference_type = value_type;
-
-  static constexpr bool is_always_lock_free = atomic_always_lock_free(sizeof(T));
-
-  static constexpr std::size_t required_alignment = alignof(T);
-
-  basic_atomic_ref() = delete;
-  basic_atomic_ref& operator=(basic_atomic_ref const&) = delete;
-
-  explicit basic_atomic_ref(T& obj) : _ptr(&obj) {}
-
-  basic_atomic_ref(basic_atomic_ref const&) = default;
-
-  T operator=(T desired) const noexcept {
-    this->store(desired);
-    return desired;
-  }
-
-  operator T() const noexcept { return this->load(); }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION void store(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    atomic_store(_ptr, desired, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T load(_MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T exchange(T desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, desired, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION bool is_lock_free() const noexcept {
-    return atomic_is_lock_free<sizeof(T), required_alignment>();
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(T& expected,
-                                            T desired,
-                                            SuccessMemoryOrder success,
-                                            FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_weak(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_weak(expected,
-                                 desired,
-                                 order,
-                                 cmpexch_failure_memory_order<_MemoryOrder>(),
-                                 MemoryScope());
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected,
-      T desired,
-      SuccessMemoryOrder success,
-      FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_strong(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_strong(expected,
-                                   desired,
-                                   order,
-                                   cmpexch_failure_memory_order<_MemoryOrder>(),
-                                   MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_add(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_add(_ptr, arg, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_sub(value_type arg, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_sub(_ptr, arg, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator+=(value_type arg) const noexcept {
-    atomic_add_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator-=(value_type arg) const noexcept {
-    atomic_sub_fetch(_ptr, arg, MemoryOrder(), MemoryScope());
-  }
-};
-
-// base class for atomic_ref<pointer-type>
-template <typename T, typename MemoryOrder, typename MemoryScope>
-struct basic_atomic_ref<T*, MemoryOrder, MemoryScope, false, false> {
- private:
-  T** _ptr;
-
- public:
-  using value_type = T*;
-  using difference_type = std::ptrdiff_t;
-
-  static constexpr bool is_always_lock_free = atomic_always_lock_free(sizeof(T));
-
-  static constexpr std::size_t required_alignment = alignof(T*);
-
-  basic_atomic_ref() = delete;
-  basic_atomic_ref& operator=(basic_atomic_ref const&) = delete;
-
-  explicit basic_atomic_ref(T*& arg) : _ptr(std::addressof(arg)) {}
-
-  basic_atomic_ref(basic_atomic_ref const&) = default;
-
-  T* operator=(T* desired) const noexcept {
-    this->store(desired);
-    return desired;
-  }
-
-  operator T*() const noexcept { return this->load(); }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION void store(T* desired,
-                            _MemoryOrder order = _MemoryOrder()) const noexcept {
-    atomic_store(_ptr, desired, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T* load(_MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION T* exchange(T* desired,
-                             _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_load(_ptr, desired, order, MemoryScope());
-  }
-
-  DESUL_FUNCTION bool is_lock_free() const noexcept {
-    return atomic_is_lock_free<sizeof(T*), required_alignment>();
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(T*& expected,
-                                            T* desired,
-                                            SuccessMemoryOrder success,
-                                            FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_weak(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_weak(
-      T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_weak(expected,
-                                 desired,
-                                 order,
-                                 cmpexch_failure_memory_order<_MemoryOrder>(),
-                                 MemoryScope());
-  }
-
-  template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T*& expected,
-      T* desired,
-      SuccessMemoryOrder success,
-      FailureMemoryOrder failure) const noexcept {
-    return atomic_compare_exchange_strong(
-        _ptr, expected, desired, success, failure, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION bool compare_exchange_strong(
-      T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return compare_exchange_strong(expected,
-                                   desired,
-                                   order,
-                                   cmpexch_failure_memory_order<_MemoryOrder>(),
-                                   MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_add(difference_type d, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_add(_ptr, _type_size(d), order, MemoryScope());
-  }
-
-  template <typename _MemoryOrder = MemoryOrder>
-  DESUL_FUNCTION value_type
-  fetch_sub(difference_type d, _MemoryOrder order = _MemoryOrder()) const noexcept {
-    return atomic_fetch_sub(_ptr, _type_size(d), order, MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator++() const noexcept {
-    return atomic_add_fetch(_ptr, _type_size(1), MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator++(int) const noexcept { return fetch_add(1); }
-
-  DESUL_FUNCTION value_type operator--() const noexcept {
-    return atomic_sub_fetch(_ptr, _type_size(1), MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator--(int) const noexcept { return fetch_sub(1); }
-
-  DESUL_FUNCTION value_type operator+=(difference_type d) const noexcept {
-    atomic_add_fetch(_ptr, _type_size(d), MemoryOrder(), MemoryScope());
-  }
-
-  DESUL_FUNCTION value_type operator-=(difference_type d) const noexcept {
-    atomic_sub_fetch(_ptr, _type_size(d), MemoryOrder(), MemoryScope());
-  }
-
- private:
-  static constexpr std::ptrdiff_t _type_size(std::ptrdiff_t d) noexcept {
-    static_assert(std::is_object<T>{}, "");
-    return d * sizeof(T);
-  }
-};
-
-}  // namespace Impl
-
-template <typename T, typename MemoryOrder, typename MemoryScope>
-struct scoped_atomic_ref : Impl::basic_atomic_ref<T, MemoryOrder, MemoryScope> {
-  explicit scoped_atomic_ref(T& obj) noexcept
-      : Impl::basic_atomic_ref<T, MemoryOrder, MemoryScope>(obj) {}
-
-  scoped_atomic_ref& operator=(scoped_atomic_ref const&) = delete;
-
-  scoped_atomic_ref(scoped_atomic_ref const&) = default;
-
-  using Impl::basic_atomic_ref<T, MemoryOrder, MemoryScope>::operator=;
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(add)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(+=, add)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(sub)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(-=, sub)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(min)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(max)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(mul)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(*=, mul)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(div)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(/=, div)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(mod)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(%=, mod)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(and)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(&=, and)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(or)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(|=, or)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(xor)
+  DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(^=, xor)
+  DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(nand)
+
+#undef DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP
+#undef DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP
+
+#define DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT(OPER, NAME)             \
+  DESUL_FUNCTION T fetch_##NAME() const noexcept {                           \
+    return desul::atomic_fetch_##NAME(ptr_, MemoryOrder(), MemoryScope());   \
+  }                                                                          \
+  DESUL_FUNCTION T NAME##_fetch() const noexcept {                           \
+    return desul::atomic_##NAME##_fetch(ptr_, MemoryOrder(), MemoryScope()); \
+  }                                                                          \
+  DESUL_FUNCTION T operator OPER() const noexcept { return NAME##_fetch(); } \
+  DESUL_FUNCTION T operator OPER(int) const noexcept { return fetch_##NAME(); }
+
+  DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT(++, inc)
+  DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT(--, dec)
+
+#undef DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT
 };
 
 }  // namespace desul

--- a/atomics/include/desul/atomics/Atomic_Ref.hpp
+++ b/atomics/include/desul/atomics/Atomic_Ref.hpp
@@ -20,30 +20,39 @@ class AtomicRef {
   T* ptr_;
 
  public:
-  explicit AtomicRef(T& obj) : ptr_(&obj) {}
+  using value_type = T;
+  using memory_order = MemoryOrder;
+  using memory_scope = MemoryScope;
 
-  T operator=(T desired) const noexcept {
+  DESUL_FUNCTION explicit AtomicRef(T& obj) : ptr_(&obj) {}
+
+  DESUL_FUNCTION T operator=(T desired) const noexcept {
     this->store(desired);
     return desired;
   }
 
-  operator T() const noexcept { return this->load(); }
-
-  using value_type = T;
+  DESUL_FUNCTION operator T() const noexcept { return this->load(); }
 
   DESUL_FUNCTION T load() const noexcept {
     return desul::atomic_load(ptr_, MemoryOrder(), MemoryScope());
   }
-  DESUL_FUNCTION void store(T val) const noexcept {
-    return desul::atomic_store(ptr_, val, MemoryOrder(), MemoryScope());
+
+  DESUL_FUNCTION void store(T desired) const noexcept {
+    return desul::atomic_store(ptr_, desired, MemoryOrder(), MemoryScope());
   }
 
+  DESUL_FUNCTION T exchange(T desired) const noexcept {
+    return desul::atomic_exchange(ptr_, desired, MemoryOrder(), MemoryScope());
+  }
+
+  // TODO compare_exchange_{weak,strong} and is_lock_free
+
 #define DESUL_IMPL_DEFINE_ATOMIC_FETCH_OP(OP)                                   \
-  DESUL_FUNCTION T fetch_##OP(T val) const noexcept {                           \
-    return desul::atomic_fetch_##OP(ptr_, val, MemoryOrder(), MemoryScope());   \
+  DESUL_FUNCTION T fetch_##OP(T arg) const noexcept {                           \
+    return desul::atomic_fetch_##OP(ptr_, arg, MemoryOrder(), MemoryScope());   \
   }                                                                             \
-  DESUL_FUNCTION T OP##_fetch(T val) const noexcept {                           \
-    return desul::atomic_##OP##_fetch(ptr_, val, MemoryOrder(), MemoryScope()); \
+  DESUL_FUNCTION T OP##_fetch(T arg) const noexcept {                           \
+    return desul::atomic_##OP##_fetch(ptr_, arg, MemoryOrder(), MemoryScope()); \
   }
 
 #define DESUL_IMPL_DEFINE_ATOMIC_COMPOUND_ASSIGNMENT_OP(COMPD_ASGMT, OP) \

--- a/atomics/include/desul/atomics/Atomic_Ref.hpp
+++ b/atomics/include/desul/atomics/Atomic_Ref.hpp
@@ -27,11 +27,11 @@ class AtomicRef {
   DESUL_FUNCTION explicit AtomicRef(T& obj) : ptr_(&obj) {}
 
   DESUL_FUNCTION T operator=(T desired) const noexcept {
-    this->store(desired);
+    store(desired);
     return desired;
   }
 
-  DESUL_FUNCTION operator T() const noexcept { return this->load(); }
+  DESUL_FUNCTION operator T() const noexcept { return load(); }
 
   DESUL_FUNCTION T load() const noexcept {
     return desul::atomic_load(ptr_, MemoryOrder(), MemoryScope());


### PR DESCRIPTION
```C++
template <typename T, typename MemoryOrder, typename MemoryScope>
struct scoped_atomic_ref;
```
The `desul::scoped_atomic_ref` was intended as an extension of the C++20 `std::atomic_ref`.
One notable change was the `MemoryOrder` template parameter that was used to modify the default order of all atomic operations.

The class template had never been used in production and we recently discovered it was broken (see #123).

We have been prototyping an implementation of a desul-based atomic accessor for `mdspan` in Kokkos and we realized that the design of `desul::scoped_atomic_ref` is not what we need.  We want to be able to use the atomic accessor in `Kokkos::View` when the atomic memory traits is specified.  It requires for the accessor to return a proxy type that supports all arithmetic operators that some potentially user-defined scalar type would provide.

This PR suggests to drop `scoped_atomic_ref` and replace it with `desul::AtomicRef` with a new design that can satisfy what Kokkos need and that we think is more in-line with the spirit of the generic atomic free functions that are provided by desul.  The main idea is that `AtomicRef` is just an alternate syntax to get to the atomics operations and that the same constraints and preconditions apply (we should seriously think about discussing these in the near future but essentially we suggest to make `AtomicRef`just behave the same as the free functions).

The current implementation is tested in kokkos/kokkos#6872

Open questions:
* should we only provide `fetch_op` member functions or do we also want `op_fetch`?
* do we all agree that trailing (templated) memory order and/or memory scope arguments in member functions are silly and we don't want them?
   ```C++
   // Alternative that I don't like
   template <typename T, typename DefaultMemoryOrder, typename DefaultMemoryScope>
   class AtomicRef {
     template <typename MemoryOrder = DefaultMemoryOrder, typename MemoryScope = DefaultMemoryScope>
     DESUL_FUNCTION T fetch_op(T val, MemoryOrder = MemoryOrder(), MemoryScope = MemoryScope()) const noexcept;
   };
   // VS what is currently proposed
   template <typename T, typename MemoryOrder, typename MemoryScope>
   class AtomicRef {
     DESUL_FUNCTION T fetch_op(T val) const noexcept;
   };
   ```
* should we consider adding an `AtomicRef` specialization for pointers with corresponding overloads of the free functions?
