### PR TITLE
Add C as a required language because of BLT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ﻿cmake_minimum_required (VERSION 3.10)
 
 project(desul
-  LANGUAGES CXX
+  LANGUAGES CXX C
   VERSION 0.1.0)
 
 # Default to C++14 if not set TODO: check to ensure this is the minimum


### PR DESCRIPTION
When enabling HIP (`cmake -DENABLE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_PREFIX_PATH=/path/to//kokkos/ ../`), I get the following error during configuration:
```
-- Configuring done (0.5s)                                                                                            
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.                        
Missing variable is:                                                                                                  
CMAKE_C_COMPILE_OBJECT                                                                                                                                                                                                                       
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.                                                                                                                                               
Missing variable is:                                                                                                                                                                                                                         
CMAKE_C_LINK_EXECUTABLE                                                                                                                                                                                                                      
-- Generating done (0.0s)                                                                                             
CMake Generate step failed.  Build files cannot be regenerated correctly
```
After some googling, it seems that it is a common error when a project forgets to add `C` as a language. When enabling HIP, BLT uses `C` 
```
[ 64%] Building C object blt/tests/smoke/CMakeFiles/blt_hip_runtime_c_smoke.dir/blt_hip_runtime_c_smoke.c.o
[ 70%] Linking C executable ../../../tests/blt_hip_runtime_c_smoke
[ 70%] Built target blt_hip_runtime_c_smoke
```
This is with CMake 3.27.7

For simplicity, this PR unconditionally adds `C` as a required language even though it's only necessary for HIP. Another solution is to rework BLT. 