### PR TITLE
 Fix using uninitialized memory in generic HOST_OR_DEVICE##_atomic_store implementation using HOST_OR_DEVICE##_atomic_fetch_oper

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -78,6 +78,8 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT
 
+// NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store to avoid
+// reading potentially uninitialized values which would yield undefined behavior.
 #define DESUL_IMPL_ATOMIC_LOAD_AND_STORE(ANNOTATION, HOST_OR_DEVICE)           \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                   \
@@ -86,9 +88,6 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
-  /* NOTE: using atomic_oper_fetch in the fallback implementation of           \
-   * atomic_store to avoid reading potentially uninitialized values            \
-   * which would yield undefined behavior. */                                  \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -89,8 +89,7 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \
-    *dest = val; /* dest might point to uninitialized memory */                \
-    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                  \
+    (void)HOST_OR_DEVICE##_atomic_oper_fetch(                                  \
         store_operator<T, const T>(), dest, val, order, scope);                \
   }
 

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -86,9 +86,9 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
-  // NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store
-  // to avoid reading potentially uninitialized values which would yield
-  // undefinied behavior.
+// NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store
+// to avoid reading potentially uninitialized values which would yield
+// undefined behavior.
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -89,6 +89,7 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \
+    *dest = val; /* dest might point to uninitialized memory */                \
     (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                  \
         store_operator<T, const T>(), dest, val, order, scope);                \
   }

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -86,9 +86,9 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
-// NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store
-// to avoid reading potentially uninitialized values which would yield
-// undefined behavior.
+  /* NOTE: using atomic_oper_fetch in the fallback implementation of           \
+   * atomic_store to avoid reading potentially uninitialized values            \
+   * which would yield undefined behavior. */                                  \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -86,6 +86,9 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
+  // NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store
+  // to avoid reading potentially uninitialized values which would yield
+  // undefinied behavior.
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \


### PR DESCRIPTION
Part of https://github.com/kokkos/kokkos/pull/7104. The implementation of `HOST_OR_DEVICE##_atomic_fetch_oper` has https://github.com/desul/desul/blob/60c1115af231f4bfe0d70a3e0cf54b2cc0ff1594/atomics/include/desul/atomics/Lock_Based_Fetch_Op_Host.hpp#L37 on the host and `dest` need to be initialized to avoid undefined behavior. From the perspective of `atomic_store` it's fine for `dest` to be uninitialized so just assign the value to be stored to make the read valid.