### PR TITLE
Add bitwise shift operations to AtomicRef

### DIFF
--- a/atomics/include/desul/atomics/Atomic_Ref.hpp
+++ b/atomics/include/desul/atomics/Atomic_Ref.hpp
@@ -95,6 +95,22 @@ class AtomicRef {
   DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT(--, dec)
 
 #undef DESUL_IMPL_DEFINE_ATOMIC_INCREMENT_DECREMENT
+
+#define DESUL_IMPL_DEFINE_ATOMIC_BITWISE_SHIFT(COMPD_ASGMT, SHFT)                 \
+  DESUL_FUNCTION T fetch_##SHFT(unsigned int arg) const noexcept {                \
+    return desul::atomic_fetch_##SHFT(ptr_, arg, MemoryOrder(), MemoryScope());   \
+  }                                                                               \
+  DESUL_FUNCTION T SHFT##_fetch(unsigned int arg) const noexcept {                \
+    return desul::atomic_##SHFT##_fetch(ptr_, arg, MemoryOrder(), MemoryScope()); \
+  }                                                                               \
+  DESUL_FUNCTION T operator COMPD_ASGMT(unsigned int arg) const noexcept {        \
+    return SHFT##_fetch(arg);                                                     \
+  }
+
+  DESUL_IMPL_DEFINE_ATOMIC_BITWISE_SHIFT(<<=, lshift)
+  DESUL_IMPL_DEFINE_ATOMIC_BITWISE_SHIFT(>>=, rshift)
+
+#undef DESUL_IMPL_DEFINE_ATOMIC_BITWISE_SHIFT
 };
 
 }  // namespace desul


### PR DESCRIPTION
Doesn't look like we have unit tests yet at all for AtomicRef?? 