### PR TITLE
SYCL: Address oneAPI 2025.0.0 deprecations

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -83,7 +83,11 @@ device_atomic_compare_exchange(
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);
@@ -114,7 +118,11 @@ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
@@ -32,7 +32,11 @@ T device_atomic_fetch_oper(const Oper& op,
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);
@@ -68,7 +72,11 @@ T device_atomic_oper_fetch(const Oper& op,
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/7196.
The free function queries were moved and deprecated in https://github.com/intel/llvm/pull/13257.