### PR TITLE
Add 128 bit atomics to overload set for SM_90

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -143,10 +143,8 @@ namespace Impl {
 
 #ifdef DESUL_HAVE_CUDA_128BIT_CAS
 template <class T, class MemoryScope>
-__device__ std::enable_if_t<sizeof(T) == 16, T> device_atomic_exchange(T* const dest,
-                                                                      T value,
-                                                                      MemoryOrderSeqCst,
-                                                                      MemoryScope) {
+__device__ std::enable_if_t<sizeof(T) == 16, T> device_atomic_exchange(
+    T* const dest, T value, MemoryOrderSeqCst, MemoryScope) {
   device_atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
   T return_val =
       device_atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
@@ -209,9 +207,10 @@ __device__ std::enable_if_t<sizeof(T) == 8, T> device_atomic_compare_exchange(
 template <class T, class MemoryOrder, class MemoryScope>
 __device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4)
 #ifdef DESUL_HAVE_CUDA_128BIT_CAS
-  && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-  , T>
+                                ,
+                            T>
 device_atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a warp or wave front
@@ -243,9 +242,10 @@ device_atomic_compare_exchange(
 template <class T, class MemoryOrder, class MemoryScope>
 __device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4)
 #ifdef DESUL_HAVE_CUDA_128BIT_CAS
-  && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-  , T>
+                                ,
+                            T>
 device_atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a warp or wave front
   T return_val;

--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -140,6 +140,31 @@ __device__ std::enable_if_t<sizeof(T) == 4 || sizeof(T) == 8, T> device_atomic_e
 
 namespace desul {
 namespace Impl {
+
+#ifdef DESUL_HAVE_CUDA_128BIT_CAS
+template <class T, class MemoryScope>
+__device__ std::enable_if_t<sizeof(T) == 16, T> device_atomic_exchange(T* const dest,
+                                                                      T value,
+                                                                      MemoryOrderSeqCst,
+                                                                      MemoryScope) {
+  device_atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val =
+      device_atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
+  device_atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
+  return return_val;
+}
+
+template <class T, class MemoryScope>
+__device__ std::enable_if_t<sizeof(T) == 16, T> device_atomic_compare_exchange(
+    T* const dest, T compare, T value, MemoryOrderSeqCst, MemoryScope) {
+  device_atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = device_atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  device_atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
+  return return_val;
+}
+#endif
+
 template <class T, class MemoryScope>
 __device__ std::enable_if_t<sizeof(T) == 4, T> device_atomic_exchange(T* const dest,
                                                                       T value,
@@ -182,7 +207,11 @@ __device__ std::enable_if_t<sizeof(T) == 8, T> device_atomic_compare_exchange(
 }
 
 template <class T, class MemoryOrder, class MemoryScope>
-__device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T>
+__device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4)
+#ifdef DESUL_HAVE_CUDA_128BIT_CAS
+  && (sizeof(T) != 16)
+#endif
+  , T>
 device_atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a warp or wave front
@@ -212,7 +241,11 @@ device_atomic_compare_exchange(
 }
 
 template <class T, class MemoryOrder, class MemoryScope>
-__device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T>
+__device__ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4)
+#ifdef DESUL_HAVE_CUDA_128BIT_CAS
+  && (sizeof(T) != 16)
+#endif
+  , T>
 device_atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid deadlock in a warp or wave front
   T return_val;

--- a/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
@@ -1,7 +1,9 @@
-#include <limits>
-
 #include <cuda.h>
+
+#include <limits>
 #if (CUDA_VERSION >= 12080) && not defined(DESUL_CUDA_ARCH_IS_PRE_HOPPER)
+// CUDA 12.8 introduced 128-bit compare and swap support on Hopper+ (compute
+// capability 9.x and higher)
 #define DESUL_HAVE_CUDA_128BIT_CAS
 #endif
 
@@ -11,8 +13,7 @@ namespace Impl {
 #include <desul/atomics/cuda/cuda_cc7_asm_exchange.inc>
 
 #ifdef DESUL_HAVE_CUDA_128BIT_CAS
-// Hopper (CC90) and above has some 128 bit atomic support
 #include <desul/atomics/cuda/cuda_cc9_asm_exchange.inc>
 #endif
-}
+}  // namespace Impl
 }  // namespace desul

--- a/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
@@ -2,5 +2,10 @@
 namespace desul {
 namespace Impl {
 #include <desul/atomics/cuda/cuda_cc7_asm_exchange.inc>
-}
+
+#ifndef DESUL_CUDA_ARCH_IS_PRE_HOPPER
+// Hopper (CC90) and above has some 128 bit atomic support
+#include <desul/atomics/cuda/cuda_cc9_asm_exchange.inc>
+#endif
+}  // namespace Impl
 }  // namespace desul

--- a/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
@@ -1,13 +1,18 @@
 #include <limits>
+
+#include <cuda.h>
+#if (CUDA_VERSION >= 12080) && not defined(DESUL_CUDA_ARCH_IS_PRE_HOPPER)
+#define DESUL_HAVE_CUDA_128BIT_CAS
+#endif
+
 namespace desul {
 namespace Impl {
-#include <cuda.h>  // to get CUDA_VERSION
 
 #include <desul/atomics/cuda/cuda_cc7_asm_exchange.inc>
 
-#if (CUDA_VERSION >= 12080) && not defined(DESUL_CUDA_ARCH_IS_PRE_HOPPER)
+#ifdef DESUL_HAVE_CUDA_128BIT_CAS
 // Hopper (CC90) and above has some 128 bit atomic support
 #include <desul/atomics/cuda/cuda_cc9_asm_exchange.inc>
 #endif
-}  // namespace Impl
+}
 }  // namespace desul

--- a/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm_exchange.hpp
@@ -1,9 +1,11 @@
 #include <limits>
 namespace desul {
 namespace Impl {
+#include <cuda.h>  // to get CUDA_VERSION
+
 #include <desul/atomics/cuda/cuda_cc7_asm_exchange.inc>
 
-#ifndef DESUL_CUDA_ARCH_IS_PRE_HOPPER
+#if (CUDA_VERSION >= 12080) && not defined(DESUL_CUDA_ARCH_IS_PRE_HOPPER)
 // Hopper (CC90) and above has some 128 bit atomic support
 #include <desul/atomics/cuda/cuda_cc9_asm_exchange.inc>
 #endif

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange.inc
@@ -1,5 +1,4 @@
 
-// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
 #define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeDevice
 #define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".gpu"
 #include "desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc"

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange.inc
@@ -1,0 +1,20 @@
+
+// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeDevice
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".gpu"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeNode
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".sys"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeCore
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".cta"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM
+

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc
@@ -1,0 +1,27 @@
+
+// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderRelaxed
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".relaxed"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderRelease
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".release"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderAcquire
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".acquire"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderAcqRel
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".acq_rel"
+#include "desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_memorder.inc
@@ -1,5 +1,4 @@
 
-// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
 #define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderRelaxed
 #define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".relaxed"
 #include "desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc"

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
@@ -1,0 +1,25 @@
+
+#define __DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE() \
+template<class ctype> \
+inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_exchange(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+  __int128_t asm_value = reinterpret_cast<__int128_t&>(value); \
+  __int128_t asm_result = 0u; \
+  asm volatile("atom.exch" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2;" : "=q"(asm_result) : "l"(dest),"q"(asm_value) : "memory"); \
+  return reinterpret_cast<ctype&>(asm_result); \
+}
+
+#define __DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE() \
+template<class ctype> \
+inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_compare_exchange(ctype* dest, ctype compare, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+  __int128_t asm_value = reinterpret_cast<__int128_t&>(value); \
+  __int128_t asm_compare = reinterpret_cast<__int128_t&>(compare); \
+  __int128_t asm_result = 0u; \
+  asm volatile("atom.cas" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2,%3;" : "=q"(asm_result) : "l"(dest),"q"(asm_compare),"q"(asm_value) : "memory"); \
+  return reinterpret_cast<ctype&>(asm_result); \
+}
+
+__DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE()
+__DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE()
+
+#undef __DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE
+#undef __DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
@@ -2,8 +2,8 @@
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_exchange(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  __int128_t asm_value = reinterpret_cast<__int128_t&>(value); \
-  __int128_t asm_result = 0u; \
+  __int128 asm_value = reinterpret_cast<__int128&>(value); \
+  __int128 asm_result = 0u; \
   asm volatile("atom.exch" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2;" : "=q"(asm_result) : "l"(dest),"q"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
 }
@@ -11,9 +11,9 @@ inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type devi
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_compare_exchange(ctype* dest, ctype compare, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  __int128_t asm_value = reinterpret_cast<__int128_t&>(value); \
-  __int128_t asm_compare = reinterpret_cast<__int128_t&>(compare); \
-  __int128_t asm_result = 0u; \
+  __int128 asm_value = reinterpret_cast<__int128&>(value); \
+  __int128 asm_compare = reinterpret_cast<__int128&>(compare); \
+  __int128 asm_result = 0u; \
   asm volatile("atom.cas" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2,%3;" : "=q"(asm_result) : "l"(dest),"q"(asm_compare),"q"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
 }


### PR DESCRIPTION
fixes #133

The [documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specification) lists 128bit atomic operations as supported for sm>=9.x.

These can be used for e.g. `complex<double>` (already covered in unit tests)

Corresponding Kokkos PR https://github.com/kokkos/kokkos/pull/8025