### PR TITLE
HIP: Implement atomic_op_fetch() in terms of atomic_fetch_op()

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_FECH_OP_HIP_HPP_
 
 #include <desul/atomics/Adapt_HIP.hpp>
+#include <desul/atomics/Operator_Function_Objects.hpp>
 
 namespace desul {
 namespace Impl {
@@ -22,6 +23,12 @@ namespace Impl {
                                    val,                                 \
                                    HIPMemoryOrder<MemoryOrder>::value,  \
                                    HIPMemoryScope<MemoryScope>::value); \
+  }                                                                     \
+  template <class MemoryOrder, class MemoryScope>                       \
+  __device__ inline T device_atomic_##OP##_fetch(                       \
+      T* ptr, T val, MemoryOrder order, MemoryScope scope) {            \
+    return OP##_fetch_operator<T, T>::apply(                            \
+        device_atomic_fetch_##OP(ptr, val, order, scope), val);         \
   }
 
 #define DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(OP) \
@@ -59,6 +66,12 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(add)
                                   -val,                                \
                                   HIPMemoryOrder<MemoryOrder>::value,  \
                                   HIPMemoryScope<MemoryScope>::value); \
+  }                                                                    \
+  template <class MemoryOrder, class MemoryScope>                      \
+  __device__ inline T device_atomic_sub_fetch(                         \
+      T* ptr, T val, MemoryOrder order, MemoryScope scope) {           \
+    return sub_fetch_operator<T, T>::apply(                            \
+        device_atomic_fetch_sub(ptr, val, order, scope), val);         \
   }
 
 DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(int)
@@ -86,6 +99,16 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(double)
                                   -1,                                             \
                                   HIPMemoryOrder<MemoryOrder>::value,             \
                                   HIPMemoryScope<MemoryScope>::value);            \
+  }                                                                               \
+  template <class MemoryOrder, class MemoryScope>                                 \
+  __device__ inline T device_atomic_inc_fetch(                                    \
+      T* ptr, MemoryOrder order, MemoryScope scope) {                             \
+    return device_atomic_fetch_inc(ptr, order, scope) + 1;                        \
+  }                                                                               \
+  template <class MemoryOrder, class MemoryScope>                                 \
+  __device__ inline T device_atomic_dec_fetch(                                    \
+      T* ptr, MemoryOrder order, MemoryScope scope) {                             \
+    return device_atomic_fetch_dec(ptr, order, scope) - 1;                        \
   }
 
 DESUL_IMPL_HIP_ATOMIC_FETCH_INC(int)

--- a/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
@@ -15,7 +15,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
-#define DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, T)                           \
+#define DESUL_IMPL_HIP_ATOMIC_OP(OP, T)                                 \
   template <class MemoryOrder, class MemoryScope>                       \
   __device__ inline T device_atomic_fetch_##OP(                         \
       T* ptr, T val, MemoryOrder, MemoryScope) {                        \
@@ -31,34 +31,34 @@ namespace Impl {
         device_atomic_fetch_##OP(ptr, val, order, scope), val);         \
   }
 
-#define DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(OP) \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, int)           \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, long)          \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, long long)     \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, unsigned int)  \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, unsigned long) \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, unsigned long long)
+#define DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(OP) \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, int)           \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, long)          \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, long long)     \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, unsigned int)  \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, unsigned long) \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, unsigned long long)
 
-#define DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(OP) \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, float)               \
-  DESUL_IMPL_HIP_ATOMIC_FETCH_OP(OP, double)
+#define DESUL_IMPL_HIP_ATOMIC_OP_FLOATING_POINT(OP) \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, float)               \
+  DESUL_IMPL_HIP_ATOMIC_OP(OP, double)
 
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(add)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(min)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(max)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(and)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(or)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(xor)
-DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(add)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(add)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(min)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(max)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(and)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(or)
+DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL(xor)
+DESUL_IMPL_HIP_ATOMIC_OP_FLOATING_POINT(add)
 // atomic min/max gives the wrong results (tested with ROCm 6.0 on Frontier)
-// DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(min)
-// DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(max)
+// DESUL_IMPL_HIP_ATOMIC_OP_FLOATING_POINT(min)
+// DESUL_IMPL_HIP_ATOMIC_OP_FLOATING_POINT(max)
 
-#undef DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT
-#undef DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL
-#undef DESUL_IMPL_HIP_ATOMIC_FETCH_OP
+#undef DESUL_IMPL_HIP_ATOMIC_OP_FLOATING_POINT
+#undef DESUL_IMPL_HIP_ATOMIC_OP_INTEGRAL
+#undef DESUL_IMPL_HIP_ATOMIC_OP
 
-#define DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(T)                             \
+#define DESUL_IMPL_HIP_ATOMIC_SUB(T)                                   \
   template <class MemoryOrder, class MemoryScope>                      \
   __device__ inline T device_atomic_fetch_sub(                         \
       T* ptr, T val, MemoryOrder, MemoryScope) {                       \
@@ -74,16 +74,16 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(add)
         device_atomic_fetch_sub(ptr, val, order, scope), val);         \
   }
 
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(int)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(long)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(long long)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(unsigned int)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(unsigned long)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(unsigned long long)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(float)
-DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(double)
+DESUL_IMPL_HIP_ATOMIC_SUB(int)
+DESUL_IMPL_HIP_ATOMIC_SUB(long)
+DESUL_IMPL_HIP_ATOMIC_SUB(long long)
+DESUL_IMPL_HIP_ATOMIC_SUB(unsigned int)
+DESUL_IMPL_HIP_ATOMIC_SUB(unsigned long)
+DESUL_IMPL_HIP_ATOMIC_SUB(unsigned long long)
+DESUL_IMPL_HIP_ATOMIC_SUB(float)
+DESUL_IMPL_HIP_ATOMIC_SUB(double)
 
-#undef DESUL_IMPL_HIP_ATOMIC_FETCH_SUB
+#undef DESUL_IMPL_HIP_ATOMIC_SUB
 
 #define DESUL_IMPL_HIP_ATOMIC_FETCH_INC(T)                                        \
   template <class MemoryOrder, class MemoryScope>                                 \


### PR DESCRIPTION
Compute atomic_op_fetch(ptr, arg) as the op applied to atomic_fetch_op(ptr, arg) and arg

Fix #136 
Corresponds to kokkos/kokkos#8010