### PR TITLE
Implement atomic_op_fetch() fallback in terms of atomic_fetch_op()

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -28,8 +28,8 @@ namespace Impl {
   template <class T, class MemoryOrder, class MemoryScope>                         \
   ANNOTATION T HOST_OR_DEVICE##_atomic_##OP_FETCH(                                 \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {          \
-    return HOST_OR_DEVICE##_atomic_oper_fetch(                                     \
-        OP_FETCH##_operator<T, const T>(), dest, val, order, scope);               \
+    return OP_FETCH##_operator<T, const T>::apply(                                 \
+        HOST_OR_DEVICE##_atomic_##FETCH_OP(dest, val, order, scope), val);         \
   }
 
 #define DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(FETCH_OP, OP_FETCH)           \
@@ -64,8 +64,8 @@ DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_dec_mod, dec_mod_fetch)
   template <class T, class MemoryOrder, class MemoryScope>                           \
   ANNOTATION T HOST_OR_DEVICE##_atomic_##OP##_fetch(                                 \
       T* const dest, const unsigned int val, MemoryOrder order, MemoryScope scope) { \
-    return HOST_OR_DEVICE##_atomic_oper_fetch(                                       \
-        OP##_fetch_operator<T, const unsigned int>(), dest, val, order, scope);      \
+    return OP##_fetch_operator<T, const unsigned int>::apply(                        \
+        HOST_OR_DEVICE##_atomic_fetch_##OP(dest, val, order, scope), val);           \
   }
 
 #define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(OP)           \
@@ -91,7 +91,7 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
   template <class T, class MemoryOrder, class MemoryScope>                           \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                     \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {            \
-    (void)HOST_OR_DEVICE##_atomic_oper_fetch(                                        \
+    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                        \
         store_fetch_operator<T, const T>(), dest, val, order, scope);                \
   }
 

--- a/atomics/include/desul/atomics/Fetch_Op_ScopeCaller.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_ScopeCaller.hpp
@@ -26,19 +26,6 @@ namespace Impl {
     T oldval = *dest;                                            \
     *dest = op.apply(oldval, val);                               \
     return oldval;                                               \
-  }                                                              \
-                                                                 \
-  template <class Oper, class T, class MemoryOrder>              \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_oper_fetch(               \
-      const Oper& op,                                            \
-      T* const dest,                                             \
-      dont_deduce_this_parameter_t<const T> val,                 \
-      MemoryOrder /*order*/,                                     \
-      MemoryScopeCaller /*scope*/) {                             \
-    T oldval = *dest;                                            \
-    T newval = op.apply(oldval, val);                            \
-    *dest = newval;                                              \
-    return newval;                                               \
   }
 
 DESUL_IMPL_ATOMIC_FETCH_OPER(DESUL_IMPL_HOST_FUNCTION, host)

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_CUDA.hpp
@@ -51,40 +51,6 @@ __device__ T device_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-__device__ T device_atomic_oper_fetch(const Oper& op,
-                                      T* const dest,
-                                      dont_deduce_this_parameter_t<const T> val,
-                                      MemoryOrder /*order*/,
-                                      MemoryScope scope) {
-  // This is a way to avoid deadlock in a warp or wave front
-  T return_val;
-  int done = 0;
-  unsigned int mask = __activemask();
-  unsigned int active = __ballot_sync(mask, 1);
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (lock_address_cuda((void*)dest, scope)) {
-        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
-        return_val = op.apply(*dest, val);
-        *dest = return_val;
-        device_atomic_thread_fence(MemoryOrderRelease(), scope);
-        unlock_address_cuda((void*)dest, scope);
-        done = 1;
-      }
-    }
-    done_active = __ballot_sync(mask, done);
-  }
-  return return_val;
-}
-
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_HIP.hpp
@@ -50,38 +50,6 @@ __device__ T device_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-__device__ T device_atomic_oper_fetch(const Oper& op,
-                                      T* const dest,
-                                      dont_deduce_this_parameter_t<const T> val,
-                                      MemoryOrder /*order*/,
-                                      MemoryScope scope) {
-  // This is a way to avoid deadlock in a warp or wave front
-  T return_val;
-  int done = 0;
-  unsigned long long int active = __ballot(1);
-  unsigned long long int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (lock_address_hip((void*)dest, scope)) {
-        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
-        return_val = op.apply(*dest, val);
-        *dest = return_val;
-        device_atomic_thread_fence(MemoryOrderRelease(), scope);
-        unlock_address_hip((void*)dest, scope);
-        done = 1;
-      }
-    }
-    done_active = __ballot(done);
-  }
-  return return_val;
-}
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_Host.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_Host.hpp
@@ -41,30 +41,6 @@ inline T host_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-inline T host_atomic_oper_fetch(const Oper& op,
-                                T* const dest,
-                                dont_deduce_this_parameter_t<const T> val,
-                                MemoryOrder /*order*/,
-                                MemoryScope scope) {
-  // Acquire a lock for the address
-  while (!lock_address((void*)dest, scope)) {
-  }
-
-  host_atomic_thread_fence(MemoryOrderAcquire(), scope);
-  T return_val = op.apply(*dest, val);
-  *dest = return_val;
-  host_atomic_thread_fence(MemoryOrderRelease(), scope);
-  unlock_address((void*)dest, scope);
-  return return_val;
-}
-
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
@@ -57,45 +57,6 @@ T device_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-T device_atomic_oper_fetch(const Oper& op,
-                           T* const dest,
-                           dont_deduce_this_parameter_t<const T> val,
-                           MemoryOrder /*order*/,
-                           MemoryScope scope) {
-  // This is a way to avoid deadlock in a subgroup
-  T return_val;
-  int done = 0;
-#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
-  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
-#else
-  auto sg = sycl::ext::oneapi::experimental::this_sub_group();
-#endif
-  using sycl::ext::oneapi::group_ballot;
-  using sycl::ext::oneapi::sub_group_mask;
-  sub_group_mask active = group_ballot(sg, 1);
-  sub_group_mask done_active = group_ballot(sg, 0);
-  while (active != done_active) {
-    if (!done) {
-      if (lock_address_sycl((void*)dest, scope)) {
-        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
-        return_val = op.apply(*dest, val);
-        *dest = return_val;
-        device_atomic_thread_fence(MemoryOrderRelease(), scope);
-        unlock_address_sycl((void*)dest, scope);
-        done = 1;
-      }
-    }
-    done_active = group_ballot(sg, done);
-  }
-  return return_val;
-}
 }  // namespace Impl
 }  // namespace desul
 


### PR DESCRIPTION
Alternate resolution of #136
Supersedes #137 and #138

Let the defaulted generic atomic_op_fetch() implementation defer to atomic_fetch_op().
Backends are still free to specialize it when appropriate and they don't need to provide a CAS-based fallback implementation any more.

See kokkos/kokkos#8014
