### PR TITLE
Provide missing atomic reduction operations and cleanup

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -18,108 +18,99 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
-#define DESUL_IMPL_ATOMIC_FETCH_OP(ANNOTATION, HOST_OR_DEVICE, FETCH_OP, OP_FETCH) \
-  template <class T, class MemoryOrder, class MemoryScope>                         \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_##FETCH_OP(                                 \
-      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {          \
-    return HOST_OR_DEVICE##_atomic_fetch_oper(                                     \
-        OP_FETCH##_operator<T, const T>(), dest, val, order, scope);               \
-  }                                                                                \
-  template <class T, class MemoryOrder, class MemoryScope>                         \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_##OP_FETCH(                                 \
-      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {          \
-    return OP_FETCH##_operator<T, const T>::apply(                                 \
-        HOST_OR_DEVICE##_atomic_##FETCH_OP(dest, val, order, scope), val);         \
+#define DESUL_IMPL_ATOMIC_FETCH_OP(ANNOTATION, HOST_OR_DEVICE, _OP)        \
+  template <class T, class MemoryOrder, class MemoryScope>                 \
+  ANNOTATION T HOST_OR_DEVICE##_atomic_fetch##_OP(                         \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {  \
+    return HOST_OR_DEVICE##_atomic_fetch_oper(                             \
+        _OP##_fetch_operator<T, const T>(), dest, val, order, scope);      \
+  }                                                                        \
+  template <class T, class MemoryOrder, class MemoryScope>                 \
+  ANNOTATION T HOST_OR_DEVICE##_atomic##_OP##_fetch(                       \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {  \
+    return _OP##_fetch_operator<T, const T>::apply(                        \
+        HOST_OR_DEVICE##_atomic_fetch##_OP(dest, val, order, scope), val); \
+  }                                                                        \
+  template <class T, class MemoryOrder, class MemoryScope>                 \
+  ANNOTATION void HOST_OR_DEVICE##_atomic##_OP(                            \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {  \
+    (void)HOST_OR_DEVICE##_atomic_fetch##_OP(dest, val, order, scope);     \
   }
 
-#define DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(FETCH_OP, OP_FETCH)           \
-  DESUL_IMPL_ATOMIC_FETCH_OP(DESUL_IMPL_HOST_FUNCTION, host, FETCH_OP, OP_FETCH) \
-  DESUL_IMPL_ATOMIC_FETCH_OP(DESUL_IMPL_DEVICE_FUNCTION, device, FETCH_OP, OP_FETCH)
+#define DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_OP)           \
+  DESUL_IMPL_ATOMIC_FETCH_OP(DESUL_IMPL_HOST_FUNCTION, host, _OP) \
+  DESUL_IMPL_ATOMIC_FETCH_OP(DESUL_IMPL_DEVICE_FUNCTION, device, _OP)
 
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_add, add_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_sub, sub_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_max, max_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_min, min_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_mul, mul_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_div, div_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_mod, mod_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_and, and_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_or, or_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_xor, xor_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_nand, nand_fetch)
+// clang-format off
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_add)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_sub)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_max)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_min)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_mul)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_div)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_mod)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_and)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_or)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_xor)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_nand)
 
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_inc_mod, inc_mod_fetch)
-DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_dec_mod, dec_mod_fetch)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_inc_mod)
+DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(_dec_mod)
+// clang-format on
 
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE
 #undef DESUL_IMPL_ATOMIC_FETCH_OP
 
-#define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(ANNOTATION, HOST_OR_DEVICE, OP)             \
+#define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(ANNOTATION, HOST_OR_DEVICE, _OP)            \
   template <class T, class MemoryOrder, class MemoryScope>                           \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_fetch_##OP(                                   \
+  ANNOTATION T HOST_OR_DEVICE##_atomic_fetch##_OP(                                   \
       T* const dest, const unsigned int val, MemoryOrder order, MemoryScope scope) { \
     return HOST_OR_DEVICE##_atomic_fetch_oper(                                       \
-        OP##_fetch_operator<T, const unsigned int>(), dest, val, order, scope);      \
+        _OP##_fetch_operator<T, const unsigned int>(), dest, val, order, scope);     \
   }                                                                                  \
   template <class T, class MemoryOrder, class MemoryScope>                           \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_##OP##_fetch(                                 \
+  ANNOTATION T HOST_OR_DEVICE##_atomic##_OP##_fetch(                                 \
       T* const dest, const unsigned int val, MemoryOrder order, MemoryScope scope) { \
-    return OP##_fetch_operator<T, const unsigned int>::apply(                        \
-        HOST_OR_DEVICE##_atomic_fetch_##OP(dest, val, order, scope), val);           \
+    return _OP##_fetch_operator<T, const unsigned int>::apply(                       \
+        HOST_OR_DEVICE##_atomic_fetch##_OP(dest, val, order, scope), val);           \
+  }                                                                                  \
+  template <class T, class MemoryOrder, class MemoryScope>                           \
+  ANNOTATION void HOST_OR_DEVICE##_atomic##_OP(                                      \
+      T* const dest, const unsigned int val, MemoryOrder order, MemoryScope scope) { \
+    (void)HOST_OR_DEVICE##_atomic##_OP(dest, val, order, scope);                     \
   }
 
-#define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(OP)           \
-  DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(DESUL_IMPL_HOST_FUNCTION, host, OP) \
-  DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(DESUL_IMPL_DEVICE_FUNCTION, device, OP)
+#define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(_OP)           \
+  DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(DESUL_IMPL_HOST_FUNCTION, host, _OP) \
+  DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT(DESUL_IMPL_DEVICE_FUNCTION, device, _OP)
 
-DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(lshift)
-DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
+DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(_lshift)
+DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(_rshift)
 
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT
 
 // NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store to avoid
 // reading potentially uninitialized values which would yield undefined behavior.
-#define DESUL_IMPL_ATOMIC_LOAD_AND_STORE(ANNOTATION, HOST_OR_DEVICE)                 \
-  template <class T, class MemoryOrder, class MemoryScope>                           \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                         \
-      const T* const dest, MemoryOrder order, MemoryScope scope) {                   \
-    return HOST_OR_DEVICE##_atomic_fetch_oper(                                       \
-        load_fetch_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
-  }                                                                                  \
-                                                                                     \
-  template <class T, class MemoryOrder, class MemoryScope>                           \
-  ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                     \
-      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {            \
-    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                        \
-        store_fetch_operator<T, const T>(), dest, val, order, scope);                \
+#define DESUL_IMPL_ATOMIC_LOAD_AND_STORE(ANNOTATION, HOST_OR_DEVICE)                  \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                          \
+      const T* const dest, MemoryOrder order, MemoryScope scope) {                    \
+    return HOST_OR_DEVICE##_atomic_fetch_oper(                                        \
+        _load_fetch_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
+  }                                                                                   \
+                                                                                      \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                      \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
+    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                         \
+        _store_fetch_operator<T, const T>(), dest, val, order, scope);                \
   }
 
 DESUL_IMPL_ATOMIC_LOAD_AND_STORE(DESUL_IMPL_HOST_FUNCTION, host)
 DESUL_IMPL_ATOMIC_LOAD_AND_STORE(DESUL_IMPL_DEVICE_FUNCTION, device)
 
 #undef DESUL_IMPL_ATOMIC_LOAD_AND_STORE
-
-#define DESUL_IMPL_ATOMIC_OP(ANNOTATION, HOST_OR_DEVICE, OP)              \
-  template <class T, class MemoryOrder, class MemoryScope>                \
-  ANNOTATION void HOST_OR_DEVICE##_atomic_##OP(                           \
-      T* const dest, const T val, MemoryOrder order, MemoryScope scope) { \
-    (void)HOST_OR_DEVICE##_atomic_fetch_##OP(dest, val, order, scope);    \
-  }
-
-#define DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(OP)           \
-  DESUL_IMPL_ATOMIC_OP(DESUL_IMPL_HOST_FUNCTION, host, OP) \
-  DESUL_IMPL_ATOMIC_OP(DESUL_IMPL_DEVICE_FUNCTION, device, OP)
-
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(add)
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(sub)
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(mul)
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(div)
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(min)
-DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE(max)
-
-#undef DESUL_IMPL_ATOMIC_OP_HOST_AND_DEVICE
-#undef DESUL_IMPL_ATOMIC_OP
 
 #define DESUL_IMPL_ATOMIC_INCREMENT_DECREMENT(ANNOTATION, HOST_OR_DEVICE) \
   template <class T, class MemoryOrder, class MemoryScope>                \

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -44,93 +44,48 @@ atomic_compare_exchange(T* dest, T cmp, T val, MemoryOrder order, MemoryScope sc
 }
 
 // Fetch_Oper atomics: return value before operation
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_add(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_add(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_add(dest, val, order, scope);)
-}
+#define DESUL_IMPL_ATOMIC_OP(_OP)                                                     \
+  DESUL_IMPL_ACC_ROUTINE_DIRECTIVE                                                    \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  DESUL_INLINE_FUNCTION T atomic_fetch##_OP(                                          \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
+    DESUL_IF_ON_DEVICE(                                                               \
+        return Impl::device_atomic_fetch##_OP(dest, val, order, scope);)              \
+    DESUL_IF_ON_HOST(return Impl::host_atomic_fetch##_OP(dest, val, order, scope);)   \
+  }                                                                                   \
+                                                                                      \
+  DESUL_IMPL_ACC_ROUTINE_DIRECTIVE                                                    \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  DESUL_INLINE_FUNCTION T atomic##_OP##_fetch(                                        \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
+    DESUL_IF_ON_DEVICE(                                                               \
+        return Impl::device_atomic##_OP##_fetch(dest, val, order, scope);)            \
+    DESUL_IF_ON_HOST(return Impl::host_atomic##_OP##_fetch(dest, val, order, scope);) \
+  }                                                                                   \
+                                                                                      \
+  DESUL_IMPL_ACC_ROUTINE_DIRECTIVE                                                    \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  DESUL_INLINE_FUNCTION void atomic##_OP(                                             \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
+    DESUL_IF_ON_DEVICE(Impl::device_atomic##_OP(dest, val, order, scope);)            \
+    DESUL_IF_ON_HOST(Impl::host_atomic##_OP(dest, val, order, scope);)                \
+  }
 
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_sub(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_sub(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_sub(dest, val, order, scope);)
-}
+DESUL_IMPL_ATOMIC_OP(_add)
+DESUL_IMPL_ATOMIC_OP(_sub)
+DESUL_IMPL_ATOMIC_OP(_max)
+DESUL_IMPL_ATOMIC_OP(_min)
+DESUL_IMPL_ATOMIC_OP(_mod)
+DESUL_IMPL_ATOMIC_OP(_mul)
+DESUL_IMPL_ATOMIC_OP(_div)
+DESUL_IMPL_ATOMIC_OP(_and)
+DESUL_IMPL_ATOMIC_OP(_or)
+DESUL_IMPL_ATOMIC_OP(_xor)
+DESUL_IMPL_ATOMIC_OP(_nand)
+DESUL_IMPL_ATOMIC_OP(_inc_mod)
+DESUL_IMPL_ATOMIC_OP(_dec_mod)
 
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_max(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_max(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_max(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_min(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_min(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_min(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_mul(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_mul(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_mul(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_div(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_div(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_div(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_mod(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_mod(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_mod(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_and(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_and(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_and(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_or(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_or(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_or(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_xor(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_xor(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_xor(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_nand(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_nand(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_nand(dest, val, order, scope);)
-}
+#undef DESUL_IMPL_ATOMIC_OP
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
 template <class T, class MemoryOrder, class MemoryScope>
@@ -150,95 +105,6 @@ DESUL_INLINE_FUNCTION T atomic_fetch_rshift(T* const dest,
                                             MemoryScope scope) {
   DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_rshift(dest, val, order, scope);)
   DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_rshift(dest, val, order, scope);)
-}
-
-// Oper Fetch atomics: return value after operation
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_add_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_add_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_add_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_sub_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_sub_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_sub_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_max_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_max_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_max_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_min_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_min_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_min_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_mul_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_mul_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_mul_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_div_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_div_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_div_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_mod_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_mod_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_mod_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_and_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_and_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_and_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_or_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_or_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_or_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_xor_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_xor_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_xor_fetch(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_nand_fetch(T* const dest, const T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_nand_fetch(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_nand_fetch(dest, val, order, scope);)
 }
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
@@ -261,6 +127,26 @@ DESUL_INLINE_FUNCTION T atomic_rshift_fetch(T* const dest,
   DESUL_IF_ON_HOST(return Impl::host_atomic_rshift_fetch(dest, val, order, scope);)
 }
 
+DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
+template <class T, class MemoryOrder, class MemoryScope>
+DESUL_INLINE_FUNCTION T atomic_lshift(T* const dest,
+                                      const unsigned int val,
+                                      MemoryOrder order,
+                                      MemoryScope scope) {
+  DESUL_IF_ON_DEVICE(return Impl::device_atomic_lshift(dest, val, order, scope);)
+  DESUL_IF_ON_HOST(return Impl::host_atomic_lshift(dest, val, order, scope);)
+}
+
+DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
+template <class T, class MemoryOrder, class MemoryScope>
+DESUL_INLINE_FUNCTION T atomic_rshift(T* const dest,
+                                      const unsigned int val,
+                                      MemoryOrder order,
+                                      MemoryScope scope) {
+  DESUL_IF_ON_DEVICE(return Impl::device_atomic_rshift(dest, val, order, scope);)
+  DESUL_IF_ON_HOST(return Impl::host_atomic_rshift(dest, val, order, scope);)
+}
+
 // Other atomics
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
@@ -280,66 +166,6 @@ DESUL_INLINE_FUNCTION void atomic_store(T* const dest,
                                         MemoryScope scope) {
   DESUL_IF_ON_DEVICE(return Impl::device_atomic_store(dest, val, order, scope);)
   DESUL_IF_ON_HOST(return Impl::host_atomic_store(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_add(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_add(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_add(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_sub(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_sub(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_sub(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_mul(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_mul(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_mul(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_div(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_div(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_div(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_min(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_min(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_min(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION void atomic_max(T* const dest,
-                                      const T val,
-                                      MemoryOrder order,
-                                      MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_max(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_max(dest, val, order, scope);)
 }
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
@@ -371,27 +197,11 @@ DESUL_INLINE_FUNCTION T atomic_fetch_inc(T* const dest,
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
 template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_inc_mod(T* const dest, T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_inc_mod(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_inc_mod(dest, val, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
 DESUL_INLINE_FUNCTION T atomic_fetch_dec(T* const dest,
                                          MemoryOrder order,
                                          MemoryScope scope) {
   DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_dec(dest, order, scope);)
   DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_dec(dest, order, scope);)
-}
-
-DESUL_IMPL_ACC_ROUTINE_DIRECTIVE
-template <class T, class MemoryOrder, class MemoryScope>
-DESUL_INLINE_FUNCTION T
-atomic_fetch_dec_mod(T* const dest, T val, MemoryOrder order, MemoryScope scope) {
-  DESUL_IF_ON_DEVICE(return Impl::device_atomic_fetch_dec_mod(dest, val, order, scope);)
-  DESUL_IF_ON_HOST(return Impl::host_atomic_fetch_dec_mod(dest, val, order, scope);)
 }
 
 DESUL_IMPL_ACC_ROUTINE_DIRECTIVE

--- a/atomics/include/desul/atomics/Operator_Function_Objects.hpp
+++ b/atomics/include/desul/atomics/Operator_Function_Objects.hpp
@@ -18,7 +18,7 @@ namespace desul {
 namespace Impl {
 
 template <class Scalar1, class Scalar2>
-struct max_fetch_operator {
+struct _max_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return (val1 > val2 ? val1 : val2);
@@ -30,7 +30,7 @@ struct max_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct min_fetch_operator {
+struct _min_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return (val1 < val2 ? val1 : val2);
@@ -70,55 +70,55 @@ constexpr DESUL_FUNCTION
 }
 
 template <class Scalar1, class Scalar2>
-struct add_fetch_operator {
+struct _add_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 + val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct sub_fetch_operator {
+struct _sub_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 - val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct mul_fetch_operator {
+struct _mul_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 * val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct div_fetch_operator {
+struct _div_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 / val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct mod_fetch_operator {
+struct _mod_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 % val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct and_fetch_operator {
+struct _and_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 & val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct or_fetch_operator {
+struct _or_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 | val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct xor_fetch_operator {
+struct _xor_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) { return val1 ^ val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct nand_fetch_operator {
+struct _nand_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return ~(val1 & val2);
@@ -126,7 +126,7 @@ struct nand_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct lshift_fetch_operator {
+struct _lshift_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 << val2;
@@ -134,7 +134,7 @@ struct lshift_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct rshift_fetch_operator {
+struct _rshift_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 >> val2;
@@ -142,7 +142,7 @@ struct rshift_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct inc_mod_fetch_operator {
+struct _inc_mod_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return ((val1 >= val2) ? Scalar1(0) : val1 + Scalar1(1));
@@ -150,7 +150,7 @@ struct inc_mod_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct dec_mod_fetch_operator {
+struct _dec_mod_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return (((val1 == Scalar1(0)) | (val1 > val2)) ? val2 : (val1 - Scalar1(1)));
@@ -158,13 +158,13 @@ struct dec_mod_fetch_operator {
 };
 
 template <class Scalar1, class Scalar2>
-struct store_fetch_operator {
+struct _store_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1&, const Scalar2& val2) { return val2; }
 };
 
 template <class Scalar1, class Scalar2>
-struct load_fetch_operator {
+struct _load_fetch_operator {
   DESUL_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2&) { return val1; }
 };


### PR DESCRIPTION
Define `atomic_{mod,and,or,xor,nand,inc_mod,dec_mod,lshift,rshift}` operations that were missing and attempt to cleanup the code.

Corresponds to kokkos/kokkos#8018