### PR TITLE
Enable tests in desul

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -60,6 +60,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DCMAKE_PREFIX_PATH=/tmp/kokkos-install \
+            -DENABLE_TESTS=ON \
             ..
           make
       - name: Test DESUL


### PR DESCRIPTION
It seems, the CI doesn't enable the tests. https://github.com/desul/desul/actions/runs/15192835955/job/42729728895 for example only prints
```
Test project /__w/desul/desul/build
    Start 1: blt_gtest_smoke
1/1 Test #1: blt_gtest_smoke ..................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```