### PR TITLE
Fix building with MSVC+Cuda

### DIFF
--- a/atomics/CMakeLists.txt
+++ b/atomics/CMakeLists.txt
@@ -40,7 +40,7 @@ if(DESUL_ENABLE_OPENMP)
   set(DESUL_ATOMICS_ENABLE_OPENMP ON)
 endif()
 if (BUILD_SHARED_LIBS)
-  set(DESUL_BUILD_SHARED_LIBS ON)
+  set(DESUL_IMPL_BUILD_SHARED_LIBS ON)
 endif()
 configure_file(
   ${PROJECT_SOURCE_DIR}/atomics/Config.hpp.cmake.in
@@ -61,7 +61,7 @@ target_include_directories (desul_atomics PUBLIC
   $<INSTALL_INTERFACE:include>
   )
 if (BUILD_SHARED_LIBS)
-  target_compile_definitions(desul_atomics PRIVATE DESUL_EXPORT_SYMBOLS)
+  target_compile_definitions(desul_atomics PRIVATE DESUL_IMPL_EXPORT_SYMBOLS)
 endif()
 
 include(CMakePackageConfigHelpers)

--- a/atomics/Config.hpp.cmake.in
+++ b/atomics/Config.hpp.cmake.in
@@ -18,6 +18,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #cmakedefine DESUL_ATOMICS_ENABLE_OPENACC
 #cmakedefine DESUL_ATOMICS_ENABLE_OPENMP
 
-#cmakedefine DESUL_BUILD_SHARED_LIBS
+#cmakedefine DESUL_IMPL_BUILD_SHARED_LIBS
 
 #endif

--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -19,8 +19,8 @@ namespace Impl {
 
 /// \brief This global variable in Host space is the central definition
 ///        of these arrays.
-DESUL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
-DESUL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
+DESUL_IMPL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
+DESUL_IMPL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -23,8 +23,8 @@ namespace Impl {
  * \brief This global variable in Host space is the central definition of these
  * arrays.
  */
-DESUL_EXPORT extern int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE_h;
-DESUL_EXPORT extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
+DESUL_IMPL_EXPORT extern int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE_h;
+DESUL_IMPL_EXPORT extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.

--- a/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -32,8 +32,8 @@ namespace Impl {
  * \brief This global variable in Host space is the central definition of these
  * arrays.
  */
-DESUL_EXPORT extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h;
-DESUL_EXPORT extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h;
+DESUL_IMPL_EXPORT extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h;
+DESUL_IMPL_EXPORT extern int32_t* SYCL_SPACE_ATOMIC_LOCKS_NODE_h;
 
 /// \brief After this call, the lock arrays used in [un]lock_address_sycl
 ///        are initialized and ready to be used.

--- a/atomics/include/desul/atomics/Macros.hpp
+++ b/atomics/include/desul/atomics/Macros.hpp
@@ -167,14 +167,14 @@ static constexpr bool desul_impl_omp_on_host() { return false; }
 #endif
 #endif
 
-#if defined(DESUL_BUILD_SHARED_LIBS) && defined(_WIN32)
-#ifdef DESUL_EXPORT_SYMBOLS
-#define DESUL_EXPORT __declspec(dllexport)
+#if defined(DESUL_IMPL_BUILD_SHARED_LIBS) && defined(_WIN32)
+#ifdef DESUL_IMPL_EXPORT_SYMBOLS
+#define DESUL_IMPL_EXPORT __declspec(dllexport)
 #else
-#define DESUL_EXPORT __declspec(dllimport)
+#define DESUL_IMPL_EXPORT __declspec(dllimport)
 #endif
 #else
-#define DESUL_EXPORT
+#define DESUL_IMPL_EXPORT
 #endif
 
 #endif  // DESUL_ATOMICS_MACROS_HPP_


### PR DESCRIPTION
Extracts the relevant changes for allowing compiling on Windows with shared libraries from kokkos/kokkos#8324. Testing (using `Kokkos`) is difficult before merging a respective pull request in `Kokkos`.

Since we don't want to use `desul`'s `CMake` configuration when bundling with `Kokkos`, using `generate_export_header` would be cumbersome (instead of extracting relevant pieces as done here).