### PR TITLE
Use `host_mirror_type` instead of `HostMirror`

### DIFF
--- a/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
+++ b/atomics/unit_tests/kokkos_based/TestAtomicOperations.hpp
@@ -60,7 +60,7 @@ template <class T, class DEVICE_TYPE>
 struct ZeroFunctor {
   typedef DEVICE_TYPE execution_space;
   typedef typename Kokkos::View<T, execution_space> type;
-  typedef typename Kokkos::View<T, execution_space>::HostMirror h_type;
+  typedef typename Kokkos::View<T, execution_space>::host_mirror_type h_type;
 
   type data;
 
@@ -76,7 +76,7 @@ template <class T, class DEVICE_TYPE>
 struct InitFunctor {
   typedef DEVICE_TYPE execution_space;
   typedef typename Kokkos::View<T, execution_space> type;
-  typedef typename Kokkos::View<T, execution_space>::HostMirror h_type;
+  typedef typename Kokkos::View<T, execution_space>::host_mirror_type h_type;
 
   type data;
   T init_value;


### PR DESCRIPTION
As per https://github.com/kokkos/kokkos/pull/8232 `HostMirror` is deprecated and `host_mirror_type` should be used instead