### PR TITLE
Don't hardcode DefaultHostExecutionSpace

### DIFF
--- a/atomics/performance_tests/kokkos_based/PerfTestAtomics.hpp
+++ b/atomics/performance_tests/kokkos_based/PerfTestAtomics.hpp
@@ -220,8 +220,9 @@ double test_atomic_perf_random_location(
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), test.dst_values);
 
   Kokkos::Timer timer;
-  Kokkos::parallel_for(
-      "desul::Tests::PerfRandLoc", Kokkos::RangePolicy(exec_space, 0, N), test);
+  Kokkos::parallel_for("desul::Tests::PerfRandLoc",
+                       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, N),
+                       test);
   Kokkos::fence();
   double time = timer.seconds();
 
@@ -237,7 +238,7 @@ double test_atomic_perf_random_location(
   int errors = 0;
   Kokkos::parallel_reduce(
       "desul::Tests::PerfRandLoc::Check",
-      Kokkos::RangePolicy(
+      Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
           Kokkos::DefaultHostExecutionSpace(), 0, result_device.extent(0)),
       KOKKOS_LAMBDA(const int i, int& count) {
         auto diff = result_device(i) - org_dst_values(i);
@@ -403,8 +404,9 @@ double test_atomic_perf_random_neighborhood(int N,
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), test.dst_values);
 
   Kokkos::Timer timer;
-  Kokkos::parallel_for(
-      "desul::Tests::PerfRandNeigh", Kokkos::RangePolicy(exec_space, 0, N), test);
+  Kokkos::parallel_for("desul::Tests::PerfRandNeigh",
+                       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, N),
+                       test);
   Kokkos::fence();
   double time = timer.seconds();
 
@@ -419,7 +421,7 @@ double test_atomic_perf_random_neighborhood(int N,
   int errors = 0;
   Kokkos::parallel_reduce(
       "desul::Tests::PerfRandNeigh::Check",
-      Kokkos::RangePolicy(
+      Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
           Kokkos::DefaultHostExecutionSpace(), 0, result_device.extent(0)),
       KOKKOS_LAMBDA(const int i, int& count) {
         auto diff = result_device(i) - org_dst_values(i);


### PR DESCRIPTION
I think https://github.com/desul/desul/pull/144 broke part of the performance tests from being compiled on with non-Host executionspaces.

