### PR TITLE
Use Clang atomic min/max GCC-style builtins

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
@@ -56,7 +56,8 @@ DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_or, std::is_integral)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_nand, std::is_integral)
 
 #if defined(__clang__)
-#if (__clang_major__ >= 17)
+#if (__clang_major__ >= 17) && \
+    (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20240000)
 // the suppression is not necessary from Clang 19 onwards
 #pragma GCC diagnostic ignored "-Watomic-alignment"
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, arithmetic_not_long_double)

--- a/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
@@ -55,6 +55,19 @@ DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_xor, std::is_integral)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_or, std::is_integral)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_nand, std::is_integral)
 
+#if defined(__clang__)
+#if (__clang_major__ >= 17)
+// the suppression is not necessary from Clang 19 onwards
+#pragma GCC diagnostic ignored "-Watomic-alignment"
+DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, arithmetic_not_long_double)
+DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_max, arithmetic_not_long_double)
+#pragma GCC diagnostic pop
+#else
+DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, std::is_integral)
+DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_max, std::is_integral)
+#endif
+#endif
+
 #undef DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP
 #undef DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP_ORDER_SCOPE
 


### PR DESCRIPTION
Clang provides atomic min/max builtins with memory ordering as a language extension since LLVM 7.
https://releases.llvm.org/7.0.0/tools/clang/docs/LanguageExtensions.html#atomic-min-max-builtins-with-memory-ordering

This PR proposes to leverage them in the GCC-style fetch_op implementation.

Corresponds to https://github.com/kokkos/kokkos/pull/8507