### PR TITLE
Fix pragma GCC diagnostic in Fetch_OP_GCC.hpp

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
@@ -59,6 +59,7 @@ DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_nand, std::is_integral)
 #if (__clang_major__ >= 17) && \
     (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20240000)
 // the suppression is not necessary from Clang 19 onwards
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Watomic-alignment"
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, arithmetic_not_long_double)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_max, arithmetic_not_long_double)


### PR DESCRIPTION
Fixes the `pragma push` clause in https://github.com/desul/desul/pull/152. We forgot to `push` the current values so that the `pop` would undo previous `push`es.