### PR TITLE
Only use __atomic_max_fetch with floating point types from LLVM 22.1 on

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_GCC.hpp
@@ -58,14 +58,9 @@ DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_or, std::is_integral)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_nand, std::is_integral)
 
 #if defined(__clang__)
-#if (__clang_major__ >= 17) && \
-    (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20240000)
-// the suppression is not necessary from Clang 19 onwards
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Watomic-alignment"
+#if (__clang_major__ * 100 + __clang_minor__) >= 2210
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, arithmetic_not_long_double)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_max, arithmetic_not_long_double)
-#pragma GCC diagnostic pop
 #else
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_min, std::is_integral)
 DESUL_IMPL_GCC_HOST_ATOMIC_FETCH_OP(_max, std::is_integral)


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/8991.

Fixes https://github.com/kokkos/kokkos/issues/8716. Fixes https://github.com/kokkos/kokkos/issues/8915.
I ran into ICEs when trying to verify https://github.com/kokkos/kokkos/pull/8984 with clang-19 and Cuda 12.2.
It seems I don't even need https://github.com/kokkos/kokkos/pull/8984 to fix the build.

Even icpx 2025.3.1 is only based on LLVM 21.1.