### PR TITLE
Leverage HIP atomic load/store compiler built-ins

### DIFF
--- a/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
@@ -117,6 +117,32 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_INC_MOD(MemoryScopeSystem, "")
 
 #undef DESUL_IMPL_HIP_ATOMIC_FETCH_INC_MOD
 
+#define DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(T)                                           \
+  template <class MemoryOrder, class MemoryScope>                                     \
+  __device__ inline T device_atomic_load(T* ptr, MemoryOrder, MemoryScope) {          \
+    return __hip_atomic_load(                                                         \
+        ptr, HIPMemoryOrder<MemoryOrder>::value, HIPMemoryScope<MemoryScope>::value); \
+  }                                                                                   \
+  template <class MemoryOrder, class MemoryScope>                                     \
+  __device__ inline void device_atomic_store(                                         \
+      T* ptr, T val, MemoryOrder, MemoryScope) {                                      \
+    return __hip_atomic_store(ptr,                                                    \
+                              val,                                                    \
+                              HIPMemoryOrder<MemoryOrder>::value,                     \
+                              HIPMemoryScope<MemoryScope>::value);                    \
+  }
+
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(int)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(long)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(long long)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned int)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned long)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned long long)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(float)
+DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(double)
+
+#undef DESUL_IMPL_HIP_ATOMIC_LOAD_STORE
+
 }  // namespace Impl
 }  // namespace desul
 


### PR DESCRIPTION
Extracting load/store performance fixes from #167 
The proposed approach is more in line with the intended way for specializing atomic operations in the backend.
I expect we will tackle fetch min and max in a follow up.
Note that I did not bother checking for existence of the compiler atomic builtin functions.
As far as I understand it, both Kokkos and RAJA only care about HIP versions that have them.