### PR TITLE
Tweak reinterpret_cast to avoid warning

### DIFF
--- a/atomics/include/desul/atomics/Lock_Free_Fetch_Op.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Fetch_Op.hpp
@@ -34,7 +34,7 @@ namespace Impl {
       MemoryOrder order,                                                             \
       MemoryScope scope) {                                                           \
     using cas_t = atomic_compare_exchange_t<T>;                                      \
-    cas_t oldval = reinterpret_cast<cas_t&>(*dest);                                  \
+    cas_t oldval = *reinterpret_cast<cas_t*>(dest);                                  \
     cas_t assume = oldval;                                                           \
                                                                                      \
     do {                                                                             \


### PR DESCRIPTION
I'm proposing this small change to avoid a warning that g++ gives when T is itself a pointer to an 8-byte type:
``warning: casting 'long int*' to 'cas_t&' {aka 'long int&'} does not dereference pointer``

Here I'm just moving the dereference of ``dest`` to the outside of the cast, so it should never cause a change in behavior but it does fix this warning ([example link on godbolt](https://godbolt.org/z/Ydo5eT6c7)).

This has been tricky to replicate within desul itself but a user of Kokkos Kernels is seeing it come up in a real application.