### PR TITLE
Fix more reinterpret_cast warnings

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -37,8 +37,8 @@ __device__ std::enable_if_t<sizeof(T) == 4, T> device_atomic_compare_exchange(
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
   unsigned int return_val = atomicCAS(reinterpret_cast<unsigned int*>(dest),
-                                      reinterpret_cast<unsigned int&>(compare),
-                                      reinterpret_cast<unsigned int&>(value));
+                                      *reinterpret_cast<unsigned int*>(&compare),
+                                      *reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 template <class T, class MemoryScope>
@@ -48,8 +48,8 @@ __device__ std::enable_if_t<sizeof(T) == 8, T> device_atomic_compare_exchange(
                 "this function assumes an unsigned long long is 64-bit");
   unsigned long long int return_val =
       atomicCAS(reinterpret_cast<unsigned long long int*>(dest),
-                reinterpret_cast<unsigned long long int&>(compare),
-                reinterpret_cast<unsigned long long int&>(value));
+                *reinterpret_cast<unsigned long long int*>(&compare),
+                *reinterpret_cast<unsigned long long int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 
@@ -90,7 +90,7 @@ __device__ std::enable_if_t<sizeof(T) == 4, T> device_atomic_exchange(
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
   unsigned int return_val = atomicExch(reinterpret_cast<unsigned int*>(dest),
-                                       reinterpret_cast<unsigned int&>(value));
+                                       *reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 template <class T, class MemoryScope>
@@ -100,7 +100,7 @@ __device__ std::enable_if_t<sizeof(T) == 8, T> device_atomic_exchange(
                 "this function assumes an unsigned long long is 64-bit");
   unsigned long long int return_val =
       atomicExch(reinterpret_cast<unsigned long long int*>(dest),
-                 reinterpret_cast<unsigned long long int&>(value));
+                 *reinterpret_cast<unsigned long long int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenACC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenACC.hpp
@@ -68,8 +68,8 @@ T device_atomic_compare_exchange(
     using cas_t =
         std::conditional_t<(sizeof(T) == 4), unsigned int, unsigned long long int>;
     cas_t return_val = atomicCAS(reinterpret_cast<cas_t*>(dest),
-                                 reinterpret_cast<cas_t&>(compare),
-                                 reinterpret_cast<cas_t&>(value));
+                                 *reinterpret_cast<cas_t*>(&compare),
+                                 *reinterpret_cast<cas_t*>(&value));
     return reinterpret_cast<T&>(return_val);
 #ifdef DESUL_CUDA_ARCH_IS_PRE_PASCAL
   } else if constexpr (std::is_same_v<T, float>) {

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -47,8 +47,8 @@ std::enable_if_t<host_atomic_always_lock_free<T>, T> host_atomic_compare_exchang
     T* dest, T compare, T value, MemoryOrder, MemoryScope) {
   using cas_t = atomic_compare_exchange_t<T>;
   cas_t retval = __sync_val_compare_and_swap(reinterpret_cast<volatile cas_t*>(dest),
-                                             reinterpret_cast<cas_t&>(compare),
-                                             reinterpret_cast<cas_t&>(value));
+                                             *reinterpret_cast<cas_t*>(&compare),
+                                             *reinterpret_cast<cas_t*>(&value));
   return reinterpret_cast<T&>(retval);
 }
 

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -76,7 +76,7 @@ std::enable_if_t<sizeof(T) == 8, T> device_atomic_exchange(T* const dest,
   sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
       *reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
-      dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
+      dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 

--- a/atomics/include/desul/atomics/Lock_Free_Fetch_Op.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Fetch_Op.hpp
@@ -21,36 +21,36 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 namespace Impl {
 
-#define DESUL_IMPL_ATOMIC_FETCH_OPER(ANNOTATION, HOST_OR_DEVICE)                     \
-  template <class Oper,                                                              \
-            class T,                                                                 \
-            class MemoryOrder,                                                       \
-            class MemoryScope,                                                       \
-            std::enable_if_t<HOST_OR_DEVICE##_atomic_always_lock_free<T>, int> = 0>  \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_fetch_oper(                                   \
-      const Oper& op,                                                                \
-      T* const dest,                                                                 \
-      dont_deduce_this_parameter_t<const T> val,                                     \
-      MemoryOrder order,                                                             \
-      MemoryScope scope) {                                                           \
-    using cas_t = atomic_compare_exchange_t<T>;                                      \
-    cas_t oldval = *reinterpret_cast<cas_t*>(dest);                                  \
-    cas_t assume = oldval;                                                           \
-                                                                                     \
-    do {                                                                             \
-      if (check_early_exit(op, reinterpret_cast<T&>(oldval), val))                   \
-        return reinterpret_cast<T&>(oldval);                                         \
-      assume = oldval;                                                               \
-      T newval = op.apply(reinterpret_cast<T&>(assume), val);                        \
-      oldval =                                                                       \
-          HOST_OR_DEVICE##_atomic_compare_exchange(reinterpret_cast<cas_t*>(dest),   \
-                                                   assume,                           \
-                                                   reinterpret_cast<cas_t&>(newval), \
-                                                   order,                            \
-                                                   scope);                           \
-    } while (assume != oldval);                                                      \
-                                                                                     \
-    return reinterpret_cast<T&>(oldval);                                             \
+#define DESUL_IMPL_ATOMIC_FETCH_OPER(ANNOTATION, HOST_OR_DEVICE)                       \
+  template <class Oper,                                                                \
+            class T,                                                                   \
+            class MemoryOrder,                                                         \
+            class MemoryScope,                                                         \
+            std::enable_if_t<HOST_OR_DEVICE##_atomic_always_lock_free<T>, int> = 0>    \
+  ANNOTATION T HOST_OR_DEVICE##_atomic_fetch_oper(                                     \
+      const Oper& op,                                                                  \
+      T* const dest,                                                                   \
+      dont_deduce_this_parameter_t<const T> val,                                       \
+      MemoryOrder order,                                                               \
+      MemoryScope scope) {                                                             \
+    using cas_t = atomic_compare_exchange_t<T>;                                        \
+    cas_t oldval = *reinterpret_cast<cas_t*>(dest);                                    \
+    cas_t assume = oldval;                                                             \
+                                                                                       \
+    do {                                                                               \
+      if (check_early_exit(op, reinterpret_cast<T&>(oldval), val))                     \
+        return reinterpret_cast<T&>(oldval);                                           \
+      assume = oldval;                                                                 \
+      T newval = op.apply(reinterpret_cast<T&>(assume), val);                          \
+      oldval =                                                                         \
+          HOST_OR_DEVICE##_atomic_compare_exchange(reinterpret_cast<cas_t*>(dest),     \
+                                                   assume,                             \
+                                                   *reinterpret_cast<cas_t*>(&newval), \
+                                                   order,                              \
+                                                   scope);                             \
+    } while (assume != oldval);                                                        \
+                                                                                       \
+    return reinterpret_cast<T&>(oldval);                                               \
   }
 
 DESUL_IMPL_ATOMIC_FETCH_OPER(DESUL_IMPL_HOST_FUNCTION, host)

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_isglobal
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_isglobal
@@ -7,7 +7,7 @@
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_AND() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_and(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.and.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1],%2;" : "=r"(asm_result) : "l"(dest),"r"(asm_value) : "memory"); \
@@ -18,7 +18,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_and(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.and.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1],%2;" : "=l"(asm_result) : "l"(dest),"l"(asm_value) : "memory"); \
@@ -31,7 +31,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_OR() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_or(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.or.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1],%2;" : "=r"(asm_result) : "l"(dest),"r"(asm_value) : "memory"); \
@@ -42,7 +42,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_or(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.or.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1],%2;" : "=l"(asm_result) : "l"(dest),"l"(asm_value) : "memory"); \
@@ -55,7 +55,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_XOR() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_xor(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.xor.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1],%2;" : "=r"(asm_result) : "l"(dest),"r"(asm_value) : "memory"); \
@@ -66,7 +66,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_xor(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   if(__isGlobal(dest)) { \
   asm volatile("atom.xor.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1],%2;" : "=l"(asm_result) : "l"(dest),"l"(asm_value) : "memory"); \

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_predicate
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_atomic_fetch_op.inc_predicate
@@ -7,7 +7,7 @@
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_AND() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_and(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \
@@ -21,7 +21,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_and(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \
@@ -37,7 +37,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_OR() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_or(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \
@@ -51,7 +51,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_or(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \
@@ -67,7 +67,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_FETCH_XOR() \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_fetch_xor(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \
@@ -81,7 +81,7 @@ inline __device__ typename std::enable_if<sizeof(ctype)==4, ctype>::type device_
 } \
 template<class ctype> \
 inline __device__ typename std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_fetch_xor(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   asm volatile( \
           "{\n\t" \

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_exchange_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_exchange_op.inc
@@ -2,14 +2,14 @@
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_exchange(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
   uint32_t asm_result = 0u; \
   asm volatile("atom.exch" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1],%2;" : "=r"(asm_result) : "l"(dest),"r"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
 } \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_exchange(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
   uint64_t asm_result = 0u; \
   asm volatile("atom.exch" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1],%2;" : "=l"(asm_result) : "l"(dest),"l"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
@@ -18,16 +18,16 @@ inline __device__ typename ::std::enable_if<sizeof(ctype)==8, ctype>::type devic
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==4, ctype>::type device_atomic_compare_exchange(ctype* dest, ctype compare, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint32_t asm_value = reinterpret_cast<uint32_t&>(value); \
-  uint32_t asm_compare = reinterpret_cast<uint32_t&>(compare); \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
+  uint32_t asm_compare = *reinterpret_cast<uint32_t*>(&compare); \
   uint32_t asm_result = 0u; \
   asm volatile("atom.cas" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1],%2,%3;" : "=r"(asm_result) : "l"(dest),"r"(asm_compare),"r"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
 } \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==8, ctype>::type device_atomic_compare_exchange(ctype* dest, ctype compare, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  uint64_t asm_value = reinterpret_cast<uint64_t&>(value); \
-  uint64_t asm_compare = reinterpret_cast<uint64_t&>(compare); \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
+  uint64_t asm_compare = *reinterpret_cast<uint64_t*>(&compare); \
   uint64_t asm_result = 0u; \
   asm volatile("atom.cas" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1],%2,%3;" : "=l"(asm_result) : "l"(dest),"l"(asm_compare),"l"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \

--- a/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc9_asm_exchange_op.inc
@@ -2,7 +2,7 @@
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_exchange(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  __int128 asm_value = reinterpret_cast<__int128&>(value); \
+  __int128 asm_value = *reinterpret_cast<__int128*>(&value); \
   __int128 asm_result = 0u; \
   asm volatile("atom.exch" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2;" : "=q"(asm_result) : "l"(dest),"q"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \
@@ -11,8 +11,8 @@ inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type devi
 #define __DESUL_IMPL_CUDA_ASM_ATOMIC_COMPARE_EXCHANGE() \
 template<class ctype> \
 inline __device__ typename ::std::enable_if<sizeof(ctype)==16, ctype>::type device_atomic_compare_exchange(ctype* dest, ctype compare, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
-  __int128 asm_value = reinterpret_cast<__int128&>(value); \
-  __int128 asm_compare = reinterpret_cast<__int128&>(compare); \
+  __int128 asm_value = *reinterpret_cast<__int128*>(&value); \
+  __int128 asm_compare = *reinterpret_cast<__int128*>(&compare); \
   __int128 asm_result = 0u; \
   asm volatile("atom.cas" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b128" " %0,[%1],%2,%3;" : "=q"(asm_result) : "l"(dest),"q"(asm_compare),"q"(asm_value) : "memory"); \
   return reinterpret_cast<ctype&>(asm_result); \


### PR DESCRIPTION
Anywhere we have to reinterpret_cast a user's ``T value`` to an integer ``cas_t``  of the same size, prefer
``*reinterpret_cast<cas_t*>(&value)`` over ``reinterpret_cast<cas_t&>(value)``.

This avoids more potential warnings of the form
```
casting 'T1*' to 'cas_t&' {aka 'T2&'} does not dereference pointer
```
that happens when T is a pointer type. All of these other examples were missed in #172.

``Compare_Exchange_MSVC.hpp`` and ``Compare_Exchange_SYCL.hpp`` files were already doing the casts this way, but I'm not sure if that was just a style difference or also to avoid warnings.