### PR TITLE
Split `load` and `store` operations so they can be implemented with special intrinsics

### DIFF
--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_CUDA_HPP_
 
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
 #include <desul/atomics/Lock_Array_CUDA.hpp>
 #include <desul/atomics/Thread_Fence_CUDA.hpp>
 #include <type_traits>
@@ -135,18 +136,6 @@ __device__ std::enable_if_t<sizeof(T) == 4 || sizeof(T) == 8, T> device_atomic_e
 }  // namespace desul
 
 #endif
-
-namespace desul {
-namespace Impl {
-template <class T>
-inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
-#ifdef DESUL_HAVE_16BYTE_LOCK_FREE_ATOMICS_DEVICE
-                                                                (sizeof(T) == 16) ||
-#endif
-                                                                (sizeof(T) == 8);
-
-}  // namespace Impl
-}  // namespace desul
 
 // SeqCst is not directly supported by PTX, need the additional fences:
 

--- a/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -10,8 +10,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_CUDA_HPP_
 
 #include <desul/atomics/Common.hpp>
-#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
 #include <desul/atomics/Lock_Array_CUDA.hpp>
+#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
 #include <desul/atomics/Thread_Fence_CUDA.hpp>
 #include <type_traits>
 

--- a/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
@@ -10,24 +10,13 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_GCC_HPP_
 
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_GCC.hpp>
 #include <desul/atomics/Lock_Array.hpp>
 #include <desul/atomics/Thread_Fence_GCC.hpp>
 #include <type_traits>
 
 namespace desul {
 namespace Impl {
-
-template <class T>
-inline constexpr bool host_atomic_always_lock_free<T, void> =
-#ifndef DESUL_HAVE_LIBATOMIC
-    ((sizeof(T) == 1 && alignof(T) == 1) || (sizeof(T) == 2 && alignof(T) == 2) ||
-     (sizeof(T) == 4 && alignof(T) == 4) || (sizeof(T) == 8 && alignof(T) == 8)
-#ifdef DESUL_HAVE_16BYTE_LOCK_FREE_ATOMICS_HOST
-     || (sizeof(T) == 16 && alignof(T) == 16)
-#endif
-         ) &&
-#endif
-    std::is_trivially_copyable<T>::value;
 
 // clang-format off
 // Disable warning for large atomics on clang 7 and up (checked with godbolt)

--- a/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_GCC.hpp
@@ -10,8 +10,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_GCC_HPP_
 
 #include <desul/atomics/Common.hpp>
-#include <desul/atomics/Lock_Free_Types_GCC.hpp>
 #include <desul/atomics/Lock_Array.hpp>
+#include <desul/atomics/Lock_Free_Types_GCC.hpp>
 #include <desul/atomics/Thread_Fence_GCC.hpp>
 #include <type_traits>
 

--- a/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
@@ -11,8 +11,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_HIP.hpp>
 #include <desul/atomics/Common.hpp>
-#include <desul/atomics/Lock_Free_Types_HIP.hpp>
 #include <desul/atomics/Lock_Array_HIP.hpp>
+#include <desul/atomics/Lock_Free_Types_HIP.hpp>
 #include <desul/atomics/Thread_Fence_HIP.hpp>
 #include <type_traits>
 

--- a/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_HIP.hpp
@@ -11,18 +11,13 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_HIP.hpp>
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_HIP.hpp>
 #include <desul/atomics/Lock_Array_HIP.hpp>
 #include <desul/atomics/Thread_Fence_HIP.hpp>
 #include <type_traits>
 
 namespace desul {
 namespace Impl {
-
-template <class T>
-inline constexpr bool device_atomic_always_lock_free<T, void> =
-    ((sizeof(T) == 1 && alignof(T) == 1) || (sizeof(T) == 4 && alignof(T) == 4) ||
-     (sizeof(T) == 8 && alignof(T) == 8)) &&
-    std::is_trivially_copyable<T>::value;
 
 template <class T, class MemoryOrder, class MemoryScope>
 __device__ std::enable_if_t<device_atomic_always_lock_free<T>, T>

--- a/atomics/include/desul/atomics/Compare_Exchange_MSVC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_MSVC.hpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_MSVC_HPP_
 
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_MSVC.hpp>
 #include <desul/atomics/Thread_Fence_MSVC.hpp>
 #include <type_traits>
 
@@ -125,13 +126,6 @@ std::enable_if_t<sizeof(T) == 16, T> host_atomic_compare_exchange(
                                        (reinterpret_cast<__int64*>(&compare)));
   return compare;
 }
-
-template <class T>
-inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 1) ||
-                                                              (sizeof(T) == 2) ||
-                                                              (sizeof(T) == 4) ||
-                                                              (sizeof(T) == 8) ||
-                                                              (sizeof(T) == 16);
 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<!host_atomic_always_lock_free<T>, T> host_atomic_compare_exchange(

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenACC.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenACC.hpp
@@ -12,15 +12,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <openacc.h>
 
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenACC.hpp>
 #include <desul/atomics/Thread_Fence_OpenACC.hpp>
 #include <type_traits>
 
 namespace desul {
 namespace Impl {
-
-template <class T>
-inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
-                                                                (sizeof(T) == 8);
 
 #ifdef __NVCOMPILER
 

--- a/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -13,14 +13,11 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_GCC.hpp>
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenMP.hpp>
 #include <desul/atomics/Thread_Fence_OpenMP.hpp>
 
 namespace desul {
 namespace Impl {
-
-template <class T>
-inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
-                                                              (sizeof(T) == 8);
 
 template <class T, class MemoryOrder, class MemoryScope>
 T host_atomic_exchange(T* dest, T value, MemoryOrder, MemoryScope) {

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -11,6 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_SYCL.hpp>
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Lock_Free_Types_SYCL.hpp>
 #include <desul/atomics/Lock_Array_SYCL.hpp>
 #include <desul/atomics/Thread_Fence_SYCL.hpp>
 
@@ -24,10 +25,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 namespace desul {
 namespace Impl {
-
-template <class T>
-inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
-                                                                (sizeof(T) == 8);
 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<sizeof(T) == 4, T> device_atomic_compare_exchange(

--- a/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -11,8 +11,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_SYCL.hpp>
 #include <desul/atomics/Common.hpp>
-#include <desul/atomics/Lock_Free_Types_SYCL.hpp>
 #include <desul/atomics/Lock_Array_SYCL.hpp>
+#include <desul/atomics/Lock_Free_Types_SYCL.hpp>
 #include <desul/atomics/Thread_Fence_SYCL.hpp>
 
 // FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include

--- a/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -88,31 +88,6 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(_rshift)
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT
 
-// NOTE: We would want to use atomic_oper_fetch in the fallback implementation of
-// atomic_store to avoid reading potentially uninitialized values which would yield
-// undefined behavior. As atomic_oper_fetch is not implemented, we have specializations
-// of the lock based fetch_oper for _store_fetch_operator that uses a default
-// constructed value instead of reading from a potentially uninitialized address.
-#define DESUL_IMPL_ATOMIC_LOAD_AND_STORE(ANNOTATION, HOST_OR_DEVICE)                  \
-  template <class T, class MemoryOrder, class MemoryScope>                            \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                          \
-      const T* const dest, MemoryOrder order, MemoryScope scope) {                    \
-    return HOST_OR_DEVICE##_atomic_fetch_oper(                                        \
-        _load_fetch_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
-  }                                                                                   \
-                                                                                      \
-  template <class T, class MemoryOrder, class MemoryScope>                            \
-  ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                      \
-      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
-    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                         \
-        _store_fetch_operator<T, const T>(), dest, val, order, scope);                \
-  }
-
-DESUL_IMPL_ATOMIC_LOAD_AND_STORE(DESUL_IMPL_HOST_FUNCTION, host)
-DESUL_IMPL_ATOMIC_LOAD_AND_STORE(DESUL_IMPL_DEVICE_FUNCTION, device)
-
-#undef DESUL_IMPL_ATOMIC_LOAD_AND_STORE
-
 #define DESUL_IMPL_ATOMIC_INCREMENT_DECREMENT(ANNOTATION, HOST_OR_DEVICE) \
   template <class T, class MemoryOrder, class MemoryScope>                \
   ANNOTATION T HOST_OR_DEVICE##_atomic_inc_fetch(                         \

--- a/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
+++ b/atomics/include/desul/atomics/Fetch_Op_HIP.hpp
@@ -117,32 +117,6 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_INC_MOD(MemoryScopeSystem, "")
 
 #undef DESUL_IMPL_HIP_ATOMIC_FETCH_INC_MOD
 
-#define DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(T)                                           \
-  template <class MemoryOrder, class MemoryScope>                                     \
-  __device__ inline T device_atomic_load(T* ptr, MemoryOrder, MemoryScope) {          \
-    return __hip_atomic_load(                                                         \
-        ptr, HIPMemoryOrder<MemoryOrder>::value, HIPMemoryScope<MemoryScope>::value); \
-  }                                                                                   \
-  template <class MemoryOrder, class MemoryScope>                                     \
-  __device__ inline void device_atomic_store(                                         \
-      T* ptr, T val, MemoryOrder, MemoryScope) {                                      \
-    return __hip_atomic_store(ptr,                                                    \
-                              val,                                                    \
-                              HIPMemoryOrder<MemoryOrder>::value,                     \
-                              HIPMemoryScope<MemoryScope>::value);                    \
-  }
-
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(int)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(long)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(long long)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned int)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned long)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(unsigned long long)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(float)
-DESUL_IMPL_HIP_ATOMIC_LOAD_STORE(double)
-
-#undef DESUL_IMPL_HIP_ATOMIC_LOAD_STORE
-
 }  // namespace Impl
 }  // namespace desul
 

--- a/atomics/include/desul/atomics/Generic.hpp
+++ b/atomics/include/desul/atomics/Generic.hpp
@@ -11,6 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <desul/atomics/Common.hpp>
 #include <desul/atomics/Compare_Exchange.hpp>
 #include <desul/atomics/Fetch_Op.hpp>
+#include <desul/atomics/Load_And_Store.hpp>
 #include <desul/atomics/Lock_Array.hpp>
 #include <desul/atomics/Macros.hpp>
 #include <desul/atomics/Thread_Fence.hpp>

--- a/atomics/include/desul/atomics/Load_And_Store.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_HPP_
+
+#include <desul/atomics/Macros.hpp>
+
+#ifdef DESUL_HAVE_GCC_ATOMICS
+#include <desul/atomics/Load_And_Store_GCC.hpp>
+#endif
+#ifdef DESUL_HAVE_MSVC_ATOMICS
+#include <desul/atomics/Load_And_Store_MSVC.hpp>
+#endif
+#ifdef DESUL_HAVE_CUDA_ATOMICS
+#include <desul/atomics/Load_And_Store_CUDA.hpp>
+#endif
+#ifdef DESUL_HAVE_HIP_ATOMICS
+#include <desul/atomics/Load_And_Store_HIP.hpp>
+#endif
+#ifdef DESUL_HAVE_OPENMP_ATOMICS
+#include <desul/atomics/Load_And_Store_OpenMP.hpp>
+#endif
+#ifdef DESUL_HAVE_OPENACC_ATOMICS
+#include <desul/atomics/Load_And_Store_OpenACC.hpp>
+#endif
+#ifdef DESUL_HAVE_SYCL_ATOMICS
+#include <desul/atomics/Load_And_Store_SYCL.hpp>
+#endif
+
+#include <desul/atomics/Load_And_Store_ScopeCaller.hpp>
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_CUDA.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_CUDA.hpp
@@ -9,9 +9,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOAD_AND_STORE_CUDA_HPP_
 #define DESUL_ATOMICS_LOAD_AND_STORE_CUDA_HPP_
 
-#include <desul/atomics/Macros.hpp>
-#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
 #include <desul/atomics/Compare_Exchange_CUDA.hpp>
+#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
+#include <desul/atomics/Macros.hpp>
 
 // Including CUDA ptx based exchange atomics
 // When building with clang we need to include the device functions always
@@ -25,7 +25,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/cuda/CUDA_asm_loadstore.hpp>
 
-// use lock-tables for the sizes that do not have an intrisinc.
+// use lock-tables for the sizes that do not have an intrinsic.
 namespace desul {
 namespace Impl {
 template <class T,
@@ -51,7 +51,7 @@ __device__ T device_atomic_load(T const* ptr,
         done = 1;
       }
     }
-    done_active = __ballot_sync(mask,done);
+    done_active = __ballot_sync(mask, done);
   }
   return ret;
 }
@@ -79,7 +79,7 @@ __device__ void device_atomic_store(T* ptr,
         done = 1;
       }
     }
-    done_active = __ballot_sync(mask,done);
+    done_active = __ballot_sync(mask, done);
   }
 }
 
@@ -87,8 +87,8 @@ __device__ void device_atomic_store(T* ptr,
 }  // namespace desul
 
 #else
-// pre-Volta there was no load and store instructions, so we have to use CAS for legacy support.
-// This is violating C++ semantics, as we potentially do a RMW op on a const.
+// pre-Volta there was no load and store instructions, so we have to use CAS for legacy
+// support. This is violating C++ semantics, as we potentially do a RMW op on a const.
 #include <desul/atomics/Compare_Exchange_CUDA.hpp>
 namespace desul {
 namespace Impl {
@@ -96,6 +96,6 @@ namespace Impl {
 DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_DEVICE_FUNCTION, device)
 
 }
-}
+}  // namespace desul
 #endif
 #endif

--- a/atomics/include/desul/atomics/Load_And_Store_CUDA.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_CUDA.hpp
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_CUDA_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_CUDA_HPP_
+
+#include <desul/atomics/Macros.hpp>
+#include <desul/atomics/Lock_Free_Types_CUDA.hpp>
+#include <desul/atomics/Compare_Exchange_CUDA.hpp>
+
+// Including CUDA ptx based exchange atomics
+// When building with clang we need to include the device functions always
+// since clang must see a consistent overload set in both device and host compilation
+// but that means we need to know on the host what to make visible, i.e. we need
+// a host side compile knowledge of architecture.
+// We simply can say DESUL proper doesn't support clang CUDA build pre Volta,
+// Kokkos has that knowledge and so I use it here, allowing in Kokkos to use
+// clang with pre Volta as CUDA compiler
+#ifndef DESUL_CUDA_ARCH_IS_PRE_VOLTA
+
+#include <desul/atomics/cuda/CUDA_asm_loadstore.hpp>
+
+// use lock-tables for the sizes that do not have an intrisinc.
+namespace desul {
+namespace Impl {
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<!device_atomic_always_lock_free<T>, int> = 0>
+__device__ T device_atomic_load(T const* ptr,
+                                MemoryOrder /*order*/,
+                                MemoryScope scope) {
+  // This is a way to avoid deadlock in a warp or wave front
+  T ret;
+  int done = 0;
+  unsigned int mask = __activemask();
+  unsigned int active = __ballot_sync(mask, 1);
+  unsigned int done_active = 0;
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_cuda((void*)ptr, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        ret = *ptr;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_cuda((void*)ptr, scope);
+        done = 1;
+      }
+    }
+    done_active = __ballot_sync(mask,done);
+  }
+  return ret;
+}
+
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<!device_atomic_always_lock_free<T>, int> = 0>
+__device__ void device_atomic_store(T* ptr,
+                                    T val,
+                                    MemoryOrder /*order*/,
+                                    MemoryScope scope) {
+  // This is a way to avoid deadlock in a warp or wave front
+  int done = 0;
+  unsigned int mask = __activemask();
+  unsigned int active = __ballot_sync(mask, 1);
+  unsigned int done_active = 0;
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_cuda((void*)ptr, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        *ptr = val;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_cuda((void*)ptr, scope);
+        done = 1;
+      }
+    }
+    done_active = __ballot_sync(mask,done);
+  }
+}
+
+}  // namespace Impl
+}  // namespace desul
+
+#else
+// pre-Volta there was no load and store instructions, so we have to use CAS for legacy support.
+// This is violating C++ semantics, as we potentially do a RMW op on a const.
+#include <desul/atomics/Compare_Exchange_CUDA.hpp>
+namespace desul {
+namespace Impl {
+
+DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_DEVICE_FUNCTION, device)
+
+}
+}
+#endif
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_GCC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_GCC.hpp
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_GCC_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_GCC_HPP_
+
+#include <desul/atomics/Adapt_GCC.hpp>
+#include <desul/atomics/Lock_Free_Types_GCC.hpp>
+#include <type_traits>
+
+namespace desul {
+namespace Impl {
+
+template <class T, class MemoryOrder, class MemoryScope>
+std::enable_if_t<host_atomic_always_lock_free<T>, T> host_atomic_load(T* ptr,
+                                                                      MemoryOrder,
+                                                                      MemoryScope) {
+  std::remove_const_t<T> ret;
+  __atomic_load(ptr, &ret, GCCMemoryOrder<MemoryOrder>::value);
+  return ret;
+}
+
+template <class T, class MemoryOrder, class MemoryScope>
+std::enable_if_t<host_atomic_always_lock_free<T>> host_atomic_store(T* ptr,
+                                                                    T val,
+                                                                    MemoryOrder,
+                                                                    MemoryScope) {
+  return __atomic_store(ptr, &val, GCCMemoryOrder<MemoryOrder>::value);
+}
+
+template <class T, class MemoryOrder, class MemoryScope>
+std::enable_if_t<!host_atomic_always_lock_free<T>, T> host_atomic_load(
+    T* ptr, MemoryOrder, MemoryScope scope) {
+  // clang-format off
+  while (!lock_address((void*)ptr, scope)) {}
+  // clang-format on
+  host_atomic_thread_fence(MemoryOrderAcquire(), scope);
+  T ret = *ptr;
+  host_atomic_thread_fence(MemoryOrderRelease(), scope);
+  unlock_address((void*)ptr, scope);
+  return ret;
+}
+
+template <class T, class MemoryOrder, class MemoryScope>
+std::enable_if_t<!host_atomic_always_lock_free<T>> host_atomic_store(
+    T* ptr, T val, MemoryOrder, MemoryScope scope) {
+  // clang-format off
+  while (!lock_address((void*)ptr, scope)) {}
+  // clang-format on
+  host_atomic_thread_fence(MemoryOrderAcquire(), scope);
+  *ptr = val;
+  host_atomic_thread_fence(MemoryOrderRelease(), scope);
+  unlock_address((void*)ptr, scope);
+}
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_HIP.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_HIP.hpp
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_HIP_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_HIP_HPP_
+
+#include <desul/atomics/Adapt_HIP.hpp>
+#include <desul/atomics/Lock_Free_Types_HIP.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<device_atomic_always_lock_free<T>, int> = 0>
+__device__ T device_atomic_load(T const* ptr, MemoryOrder, MemoryScope) {
+  return __hip_atomic_load(
+      ptr, HIPMemoryOrder<MemoryOrder>::value, HIPMemoryScope<MemoryScope>::value);
+}
+
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<device_atomic_always_lock_free<T>, int> = 0>
+__device__ void device_atomic_store(T* ptr, T val, MemoryOrder, MemoryScope) {
+  __hip_atomic_store(
+      ptr, val, HIPMemoryOrder<MemoryOrder>::value, HIPMemoryScope<MemoryScope>::value);
+}
+
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<!device_atomic_always_lock_free<T>, int> = 0>
+__device__ T device_atomic_load(T const* ptr,
+                                MemoryOrder /*order*/,
+                                MemoryScope scope) {
+  // This is a way to avoid deadlock in a warp or wave front
+  T ret;
+  int done = 0;
+  unsigned long long int active = __ballot(1);
+  unsigned long long int done_active = 0;
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_hip((void*)ptr, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        ret = *ptr;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_hip((void*)ptr, scope);
+        done = 1;
+      }
+    }
+    done_active = __ballot(done);
+  }
+  return ret;
+}
+
+template <class T,
+          class MemoryOrder,
+          class MemoryScope,
+          std::enable_if_t<!device_atomic_always_lock_free<T>, int> = 0>
+__device__ void device_atomic_store(T* ptr,
+                                    T val,
+                                    MemoryOrder /*order*/,
+                                    MemoryScope scope) {
+  // This is a way to avoid deadlock in a warp or wave front
+  int done = 0;
+  unsigned long long int active = __ballot(1);
+  unsigned long long int done_active = 0;
+  while (active != done_active) {
+    if (!done) {
+      if (lock_address_hip((void*)ptr, scope)) {
+        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
+        *ptr = val;
+        device_atomic_thread_fence(MemoryOrderRelease(), scope);
+        unlock_address_hip((void*)ptr, scope);
+        done = 1;
+      }
+    }
+    done_active = __ballot(done);
+  }
+}
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
@@ -17,7 +17,7 @@ namespace desul {
 namespace Impl {
 
 // MSVC does only provide _InterlockedCompareExchange but no load and store intrinsics.
-// If we can require c++20 we can switch to std::atomic
+// If we can require c++20 we can switch to std::atomic_ref
 
 DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_HOST_FUNCTION, host)
 

--- a/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
@@ -9,9 +9,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOAD_AND_STORE_MSVC_HPP_
 #define DESUL_ATOMICS_LOAD_AND_STORE_MSVC_HPP_
 
-#include <desul/atomics/Macros.hpp>
-#include <desul/atomics/Lock_Free_Types_MSVC.hpp>
 #include <desul/atomics/Compare_Exchange_MSVC.hpp>
+#include <desul/atomics/Lock_Free_Types_MSVC.hpp>
+#include <desul/atomics/Macros.hpp>
 
 namespace desul {
 namespace Impl {

--- a/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_MSVC.hpp
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_MSVC_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_MSVC_HPP_
+
+#include <desul/atomics/Macros.hpp>
+#include <desul/atomics/Lock_Free_Types_MSVC.hpp>
+#include <desul/atomics/Compare_Exchange_MSVC.hpp>
+
+namespace desul {
+namespace Impl {
+
+// MSVC does only provide _InterlockedCompareExchange but no load and store intrinsics.
+// If we can require c++20 we can switch to std::atomic
+
+DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_HOST_FUNCTION, host)
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_OpenACC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_OpenACC.hpp
@@ -9,9 +9,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOAD_AND_STORE_OPENACC_HPP_
 #define DESUL_ATOMICS_LOAD_AND_STORE_OPENACC_HPP_
 
-#include <desul/atomics/Macros.hpp>
-#include <desul/atomics/Lock_Free_Types_OpenACC.hpp>
 #include <desul/atomics/Compare_Exchange_OpenACC.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenACC.hpp>
+#include <desul/atomics/Macros.hpp>
 
 namespace desul {
 namespace Impl {

--- a/atomics/include/desul/atomics/Load_And_Store_OpenACC.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_OpenACC.hpp
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_OPENACC_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_OPENACC_HPP_
+
+#include <desul/atomics/Macros.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenACC.hpp>
+#include <desul/atomics/Compare_Exchange_OpenACC.hpp>
+
+namespace desul {
+namespace Impl {
+
+DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_DEVICE_FUNCTION, device)
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_OpenMP.hpp
@@ -9,9 +9,9 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOAD_AND_STORE_OPENMP_HPP_
 #define DESUL_ATOMICS_LOAD_AND_STORE_OPENMP_HPP_
 
-#include <desul/atomics/Macros.hpp>
-#include <desul/atomics/Lock_Free_Types_OpenMP.hpp>
 #include <desul/atomics/Compare_Exchange_OpenMP.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenMP.hpp>
+#include <desul/atomics/Macros.hpp>
 
 namespace desul {
 namespace Impl {

--- a/atomics/include/desul/atomics/Load_And_Store_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_OpenMP.hpp
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_OPENMP_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_OPENMP_HPP_
+
+#include <desul/atomics/Macros.hpp>
+#include <desul/atomics/Lock_Free_Types_OpenMP.hpp>
+#include <desul/atomics/Compare_Exchange_OpenMP.hpp>
+
+namespace desul {
+namespace Impl {
+
+DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(DESUL_IMPL_HOST_FUNCTION, host)
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Load_And_Store_SYCL.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_SYCL.hpp
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_SYCL_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_SYCL_HPP_
+
+#include <desul/atomics/Adapt_SYCL.hpp>
+#include <desul/atomics/Lock_Free_Types_SYCL.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T, class MemoryOrder, class MemoryScope>
+void 
+device_atomic_store(
+    T* ptr, T val, MemoryOrder, MemoryScope scope) {
+      	if constexpr(sizeof(T) ==4 ) {
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+	    	sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned int&>(*ptr));
+    ref.store(reinterpret_cast<unsigned int&>(val)); } else if constexpr(sizeof(T)==8) {
+	      static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long is 64-bit");
+  sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned long long&>(*ptr));
+    ref.store(reinterpret_cast<unsigned long long&>(val));
+  } else {
+    // This is a way to avoid deadlock in a subgroup
+    int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+    auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
+    auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
+    using sycl::ext::oneapi::group_ballot;
+    using sycl::ext::oneapi::sub_group_mask;
+    sub_group_mask active = group_ballot(sg, 1);
+    sub_group_mask done_active = group_ballot(sg, 0);
+    while (active != done_active) {
+      if (!done) {
+        if (lock_address_sycl((void*)ptr, scope)) {
+          if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+            atomic_thread_fence(MemoryOrderRelease(), scope);
+          atomic_thread_fence(MemoryOrderAcquire(), scope);
+          *ptr = val;
+          unlock_address_sycl((void*)ptr, scope);
+          done = 1;
+        }
+      }
+      done_active = group_ballot(sg, done);
+    }
+  }
+}
+
+template <class T, class MemoryOrder, class MemoryScope>
+T device_atomic_load(const T* ptr,
+                                                                          MemoryOrder,
+                                                                          MemoryScope scope) {
+        if constexpr(sizeof(T) ==4 ) {
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+                sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned int&>(const_cast<T&>(*ptr)));
+ T sycl_return = ref.load();
+	     	return reinterpret_cast<T&>(sycl_return); } else if constexpr(sizeof(T)==8) {
+              static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long is 64-bit");
+  sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned long long&>(const_cast<T&>(*ptr)));
+ T sycl_return = ref.load();
+  return reinterpret_cast<T&>(sycl_return); 
+  } else {
+    // This is a way to avoid deadlock in a subgroup
+    T ret;
+    int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+    auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
+    auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
+    using sycl::ext::oneapi::group_ballot;
+    using sycl::ext::oneapi::sub_group_mask;
+    sub_group_mask active = group_ballot(sg, 1);
+    sub_group_mask done_active = group_ballot(sg, 0);
+    while (active != done_active) {
+      if (!done) {
+        if (lock_address_sycl((void*)ptr, scope)) {
+          if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+            atomic_thread_fence(MemoryOrderRelease(), scope);
+          atomic_thread_fence(MemoryOrderAcquire(), scope);
+          ret = *ptr;
+          unlock_address_sycl((void*)ptr, scope);
+          done = 1;
+        }
+      }
+      done_active = group_ballot(sg, done);
+    }
+    return ret;
+  }
+}
+
+}  // namespace Impl
+}  // namespace desul
+
+#endif
+

--- a/atomics/include/desul/atomics/Load_And_Store_SYCL.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_SYCL.hpp
@@ -16,17 +16,18 @@ namespace desul {
 namespace Impl {
 
 template <class T, class MemoryOrder, class MemoryScope>
-void 
-device_atomic_store(
-    T* ptr, T val, MemoryOrder, MemoryScope scope) {
-      	if constexpr(sizeof(T) ==4 ) {
-  static_assert(sizeof(unsigned int) == 4,
-                "this function assumes an unsigned int is 32-bit");
-	    	sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned int&>(*ptr));
-    ref.store(reinterpret_cast<unsigned int&>(val)); } else if constexpr(sizeof(T)==8) {
-	      static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long is 64-bit");
-  sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned long long&>(*ptr));
+void device_atomic_store(T* ptr, T val, MemoryOrder, MemoryScope scope) {
+  if constexpr (sizeof(T) == 4) {
+    static_assert(sizeof(unsigned int) == 4,
+                  "this function assumes an unsigned int is 32-bit");
+    sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(
+        reinterpret_cast<unsigned int&>(*ptr));
+    ref.store(reinterpret_cast<unsigned int&>(val));
+  } else if constexpr (sizeof(T) == 8) {
+    static_assert(sizeof(unsigned long long int) == 8,
+                  "this function assumes an unsigned long long is 64-bit");
+    sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(
+        reinterpret_cast<unsigned long long&>(*ptr));
     ref.store(reinterpret_cast<unsigned long long&>(val));
   } else {
     // This is a way to avoid deadlock in a subgroup
@@ -57,20 +58,21 @@ device_atomic_store(
 }
 
 template <class T, class MemoryOrder, class MemoryScope>
-T device_atomic_load(const T* ptr,
-                                                                          MemoryOrder,
-                                                                          MemoryScope scope) {
-        if constexpr(sizeof(T) ==4 ) {
-  static_assert(sizeof(unsigned int) == 4,
-                "this function assumes an unsigned int is 32-bit");
-                sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned int&>(const_cast<T&>(*ptr)));
- T sycl_return = ref.load();
-	     	return reinterpret_cast<T&>(sycl_return); } else if constexpr(sizeof(T)==8) {
-              static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long is 64-bit");
-  sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(reinterpret_cast<unsigned long long&>(const_cast<T&>(*ptr)));
- T sycl_return = ref.load();
-  return reinterpret_cast<T&>(sycl_return); 
+T device_atomic_load(const T* ptr, MemoryOrder, MemoryScope scope) {
+  if constexpr (sizeof(T) == 4) {
+    static_assert(sizeof(unsigned int) == 4,
+                  "this function assumes an unsigned int is 32-bit");
+    sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> ref(
+        reinterpret_cast<unsigned int&>(const_cast<T&>(*ptr)));
+    auto sycl_return = ref.load();
+    return reinterpret_cast<T&>(sycl_return);
+  } else if constexpr (sizeof(T) == 8) {
+    static_assert(sizeof(unsigned long long int) == 8,
+                  "this function assumes an unsigned long long is 64-bit");
+    sycl_atomic_ref<unsigned long long, MemoryOrder, MemoryScope> ref(
+        reinterpret_cast<unsigned long long&>(const_cast<T&>(*ptr)));
+    auto sycl_return = ref.load();
+    return reinterpret_cast<T&>(sycl_return);
   } else {
     // This is a way to avoid deadlock in a subgroup
     T ret;
@@ -105,4 +107,3 @@ T device_atomic_load(const T* ptr,
 }  // namespace desul
 
 #endif
-

--- a/atomics/include/desul/atomics/Load_And_Store_ScopeCaller.hpp
+++ b/atomics/include/desul/atomics/Load_And_Store_ScopeCaller.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_ATOMICS_LOAD_AND_STORE_SCOPECALLER_HPP_
+#define DESUL_ATOMICS_LOAD_AND_STORE_SCOPECALLER_HPP_
+
+#include <desul/atomics/Common.hpp>
+#include <desul/atomics/Macros.hpp>
+
+namespace desul {
+
+#define DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MEMORY_ORDER)                            \
+  template <class T>                                                                   \
+  DESUL_INLINE_FUNCTION T atomic_load(T const* ptr, MEMORY_ORDER, MemoryScopeCaller) { \
+    return *ptr;                                                                       \
+  }                                                                                    \
+                                                                                       \
+  template <class T>                                                                   \
+  DESUL_INLINE_FUNCTION void atomic_store(                                             \
+      T* ptr, T val, MEMORY_ORDER, MemoryScopeCaller) {                                \
+    *ptr = val;                                                                        \
+  }
+
+DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MemoryOrderSeqCst)
+DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MemoryOrderAcqRel)
+DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MemoryOrderRelease)
+DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MemoryOrderAcquire)
+DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER(MemoryOrderRelaxed)
+
+#undef DESUL_IMPL_LOAD_AND_STORE_SCOPECALLER
+
+}  // namespace desul
+
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_CUDA.hpp
@@ -16,9 +16,6 @@ namespace Impl {
 
 template <class T>
 inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
-#ifdef DESUL_HAVE_16BYTE_LOCK_FREE_ATOMICS_DEVICE
-                                                                (sizeof(T) == 16) ||
-#endif
                                                                 (sizeof(T) == 8);
 
 }  // namespace Impl

--- a/atomics/include/desul/atomics/Lock_Free_Types_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_CUDA.hpp
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_CUDA_HPP_
+#define DESUL_LOCK_FREE_TYPES_CUDA_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
+#ifdef DESUL_HAVE_16BYTE_LOCK_FREE_ATOMICS_DEVICE
+                                                                (sizeof(T) == 16) ||
+#endif
+                                                                (sizeof(T) == 8);
+
+}  // namespace Impl
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_GCC.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_GCC.hpp
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_GCC_HPP_
+#define DESUL_LOCK_FREE_TYPES_GCC_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool host_atomic_always_lock_free<T, void> =
+#ifndef DESUL_HAVE_LIBATOMIC
+    ((sizeof(T) == 1 && alignof(T) == 1) || (sizeof(T) == 2 && alignof(T) == 2) ||
+     (sizeof(T) == 4 && alignof(T) == 4) || (sizeof(T) == 8 && alignof(T) == 8)
+#ifdef DESUL_HAVE_16BYTE_LOCK_FREE_ATOMICS_HOST
+     || (sizeof(T) == 16 && alignof(T) == 16)
+#endif
+         ) &&
+#endif
+    std::is_trivially_copyable<T>::value;
+
+}
+}
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_GCC.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_GCC.hpp
@@ -26,6 +26,6 @@ inline constexpr bool host_atomic_always_lock_free<T, void> =
 #endif
     std::is_trivially_copyable<T>::value;
 
-}
-}
+}  // namespace Impl
+}  // namespace desul
 #endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_HIP.hpp
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_HIP_HPP_
+#define DESUL_LOCK_FREE_TYPES_HIP_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool device_atomic_always_lock_free<T, void> =
+    ((sizeof(T) == 1 && alignof(T) == 1) || (sizeof(T) == 4 && alignof(T) == 4) ||
+     (sizeof(T) == 8 && alignof(T) == 8)) &&
+    std::is_trivially_copyable<T>::value;
+
+}  // namespace Impl
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_MSVC.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_MSVC.hpp
@@ -22,5 +22,5 @@ inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 1) |
                                                               (sizeof(T) == 16);
 
 }
-}
+}  // namespace desul
 #endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_MSVC.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_MSVC.hpp
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_MSVC_HPP_
+#define DESUL_LOCK_FREE_TYPES_MSVC_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 1) ||
+                                                              (sizeof(T) == 2) ||
+                                                              (sizeof(T) == 4) ||
+                                                              (sizeof(T) == 8) ||
+                                                              (sizeof(T) == 16);
+
+}
+}
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_OpenACC.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_OpenACC.hpp
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_OPENACC_HPP_
+#define DESUL_LOCK_FREE_TYPES_OPENACC_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
+                                                                (sizeof(T) == 8);
+
+}  // namespace Impl
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_OpenMP.hpp
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_OPENMP_HPP_
+#define DESUL_LOCK_FREE_TYPES_OPENMP_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
+                                                              (sizeof(T) == 8);
+
+}
+}
+#endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_OpenMP.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_OpenMP.hpp
@@ -19,5 +19,5 @@ inline constexpr bool host_atomic_always_lock_free<T, void> = (sizeof(T) == 4) |
                                                               (sizeof(T) == 8);
 
 }
-}
+}  // namespace desul
 #endif

--- a/atomics/include/desul/atomics/Lock_Free_Types_SYCL.hpp
+++ b/atomics/include/desul/atomics/Lock_Free_Types_SYCL.hpp
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2019, Lawrence Livermore National Security, LLC
+and DESUL project contributors. See the COPYRIGHT file for details.
+Source: https://github.com/desul/desul
+
+SPDX-License-Identifier: (BSD-3-Clause)
+*/
+
+#ifndef DESUL_LOCK_FREE_TYPES_SYCL_HPP_
+#define DESUL_LOCK_FREE_TYPES_SYCL_HPP_
+
+#include <desul/atomics/Common.hpp>
+
+namespace desul {
+namespace Impl {
+
+template <class T>
+inline constexpr bool device_atomic_always_lock_free<T, void> = (sizeof(T) == 4) ||
+                                                                (sizeof(T) == 8);
+
+}  // namespace Impl
+}  // namespace desul
+#endif

--- a/atomics/include/desul/atomics/Macros.hpp
+++ b/atomics/include/desul/atomics/Macros.hpp
@@ -177,4 +177,25 @@ static constexpr bool desul_impl_omp_on_host() { return false; }
 #define DESUL_IMPL_EXPORT
 #endif
 
+// Fallback Load and store implementations
+// NOTE: We would want to use atomic_oper_fetch in the fallback implementation of
+// atomic_store to avoid reading potentially uninitialized values which would yield
+// undefined behavior. As atomic_oper_fetch is not implemented, we have specializations
+// of the lock based fetch_oper for _store_fetch_operator that uses a default
+// constructed value instead of reading from a potentially uninitialized address.
+#define DESUL_IMPL_ATOMIC_LOAD_AND_STORE_WITH_CAS(ANNOTATION, HOST_OR_DEVICE)         \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                          \
+      const T* const dest, MemoryOrder order, MemoryScope scope) {                    \
+    return HOST_OR_DEVICE##_atomic_fetch_oper(                                        \
+        _load_fetch_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
+  }                                                                                   \
+                                                                                      \
+  template <class T, class MemoryOrder, class MemoryScope>                            \
+  ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                      \
+      T* const dest, const T val, MemoryOrder order, MemoryScope scope) {             \
+    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                         \
+        _store_fetch_operator<T, const T>(), dest, val, order, scope);                \
+  }
+
 #endif  // DESUL_ATOMICS_MACROS_HPP_

--- a/atomics/include/desul/atomics/cuda/CUDA_asm_loadstore.hpp
+++ b/atomics/include/desul/atomics/cuda/CUDA_asm_loadstore.hpp
@@ -1,0 +1,9 @@
+#include <limits>
+
+namespace desul {
+namespace Impl {
+
+#include <desul/atomics/cuda/cuda_cc7_asm_loadstore.inc>
+
+}  // namespace Impl
+}  // namespace desul

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_load_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_load_op.inc
@@ -1,0 +1,25 @@
+#define __DESUL_IMPL_CUDA_ASM_ATOMIC_LOAD() \
+template<class ctype> \
+inline __device__ ctype device_atomic_load(const ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, typename std::enable_if<(sizeof(ctype)==4), __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE>::type) { \
+  uint32_t asm_result = 0u; \
+  if(__isGlobal(dest)) { \
+    asm volatile("ld.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1];" : "=r"(asm_result) : "l"(dest) : "memory"); \
+  } else { \
+    asm volatile("ld" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " %0,[%1];" : "=r"(asm_result) : "l"(dest) : "memory"); \
+  } \
+  return reinterpret_cast<ctype&>(asm_result); \
+} \
+template<class ctype> \
+inline __device__ ctype device_atomic_load(const ctype* dest, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, typename std::enable_if<(sizeof(ctype)==8), __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE>::type) { \
+  uint64_t asm_result = 0u; \
+  if(__isGlobal(dest)) { \
+    asm volatile("ld.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1];" : "=l"(asm_result) : "l"(dest) : "memory"); \
+  } else { \
+    asm volatile("ld" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " %0,[%1];" : "=l"(asm_result) : "l"(dest) : "memory"); \
+  } \
+  return reinterpret_cast<ctype&>(asm_result); \
+}
+
+__DESUL_IMPL_CUDA_ASM_ATOMIC_LOAD()
+
+#undef __DESUL_IMPL_CUDA_ASM_ATOMIC_LOAD

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_loadstore.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_loadstore.inc
@@ -1,0 +1,18 @@
+// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeDevice
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".gpu"
+#include "desul/atomics/cuda/cuda_cc7_asm_loadstore_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeNode
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".sys"
+#include "desul/atomics/cuda/cuda_cc7_asm_loadstore_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE MemoryScopeCore
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".cta"
+#include "desul/atomics/cuda/cuda_cc7_asm_loadstore_memorder.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_loadstore_memorder.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_loadstore_memorder.inc
@@ -1,0 +1,20 @@
+// Non returning atomic operation (ptx red instruction) only exists for relaxed and release memorder
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderRelaxed
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".relaxed"
+#include "desul/atomics/cuda/cuda_cc7_asm_load_op.inc"
+#include "desul/atomics/cuda/cuda_cc7_asm_store_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderRelease
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".release"
+#include "desul/atomics/cuda/cuda_cc7_asm_store_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM
+
+
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER MemoryOrderAcquire
+#define __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM ".acquire"
+#include "desul/atomics/cuda/cuda_cc7_asm_load_op.inc"
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER
+#undef __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM

--- a/atomics/include/desul/atomics/cuda/cuda_cc7_asm_store_op.inc
+++ b/atomics/include/desul/atomics/cuda/cuda_cc7_asm_store_op.inc
@@ -1,0 +1,23 @@
+#define __DESUL_IMPL_CUDA_ASM_ATOMIC_STORE() \
+template<class ctype> \
+inline __device__ typename ::std::enable_if<sizeof(ctype)==4, void>::type device_atomic_store(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+  uint32_t asm_value = *reinterpret_cast<uint32_t*>(&value); \
+  if(__isGlobal(dest)) { \
+    asm volatile("st.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " [%0],%1;" :: "l"(dest),"r"(asm_value) : "memory"); \
+  } else { \
+    asm volatile("st" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b32" " [%0],%1;" :: "l"(dest),"r"(asm_value) : "memory"); \
+  } \
+} \
+template<class ctype> \
+inline __device__ typename ::std::enable_if<sizeof(ctype)==8>::type device_atomic_store(ctype* dest, ctype value, __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER, __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE) { \
+  uint64_t asm_value = *reinterpret_cast<uint64_t*>(&value); \
+  if(__isGlobal(dest)) { \
+    asm volatile("st.global" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " [%0],%1;" :: "l"(dest),"l"(asm_value) : "memory"); \
+  } else { \
+    asm volatile("st" __DESUL_IMPL_CUDA_ASM_MEMORY_ORDER_ASM __DESUL_IMPL_CUDA_ASM_MEMORY_SCOPE_ASM ".b64" " [%0],%1;" :: "l"(dest),"l"(asm_value) : "memory"); \
+  } \
+}
+
+__DESUL_IMPL_CUDA_ASM_ATOMIC_STORE()
+
+#undef __DESUL_IMPL_CUDA_ASM_ATOMIC_STORE


### PR DESCRIPTION
This is part of a general redesign to fix the semantic violation described in #164 and the performance problem identified in https://github.com/desul/desul/pull/167.

The main idea is to separate load and store and not implement them with CAS. This can then be used in the impl for `min` and `max` as a next step.

BUT: with this switch, we basically can only provide lock-free atomics if we have `load`, `store` and `cas` for that size. This means, that 128bit atomics (x86, hopper, and arm only provide `cas` but no `load` or `store`) will go through lock tables.

Corresponding Kokkos PR: https://github.com/kokkos/kokkos/pull/9219