### PR TITLE
Relax RDC requirement 

### DIFF
--- a/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -61,11 +61,15 @@ void finalize_lock_arrays_cuda();
 /// That is the purpose of the ensure_cuda_lock_arrays_on_device function.
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
 
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
 

--- a/atomics/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/atomics/include/desul/atomics/Lock_Array_HIP.hpp
@@ -65,11 +65,15 @@ void finalize_lock_arrays_hip();
  */
 #ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
 
 #ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
 

--- a/atomics/include/desul/atomics/Macros.hpp
+++ b/atomics/include/desul/atomics/Macros.hpp
@@ -18,10 +18,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_IMPL_CUDA_RDC
 #endif
 
-#if (defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) &&  \
-     !defined(DESUL_IMPL_CUDA_RDC)) ||                            \
-    (!defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) && \
-     defined(DESUL_IMPL_CUDA_RDC))
+#if (defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) && \
+     !defined(DESUL_IMPL_CUDA_RDC))
 #error Relocatable device code mode incompatible with desul atomics configuration
 #endif
 
@@ -31,10 +29,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #endif
 
 #ifdef DESUL_ATOMICS_ENABLE_HIP
-#if (defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) &&  \
-     !defined(__CLANG_RDC__)) ||                                 \
-    (!defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) && \
-     defined(__CLANG_RDC__))
+#if (defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) && !defined(__CLANG_RDC__))
 #error Relocatable device code mode incompatible with desul atomics configuration
 #endif
 #endif

--- a/atomics/src/Lock_Array_CUDA.cpp
+++ b/atomics/src/Lock_Array_CUDA.cpp
@@ -24,11 +24,12 @@ namespace desul {
 
 namespace {
 
-__global__ void init_lock_arrays_cuda_kernel() {
+__global__ void init_lock_arrays_cuda_kernel(int32_t* device_locks,
+                                             int32_t* node_locks) {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < CUDA_SPACE_ATOMIC_MASK + 1) {
-    Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE[i] = 0;
-    Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE[i] = 0;
+    device_locks[i] = 0;
+    node_locks[i] = 0;
   }
 }
 
@@ -68,12 +69,14 @@ void init_lock_arrays_cuda() {
   check_error_and_throw_cuda(error_malloc2,
                              "init_lock_arrays_cuda: cudaMalloc host locks");
 
-  auto error_sync1 = cudaDeviceSynchronize();
+#ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
   copy_cuda_lock_arrays_to_device();
-  check_error_and_throw_cuda(error_sync1, "init_lock_arrays_cuda: post mallocs");
-  init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
-  auto error_sync2 = cudaDeviceSynchronize();
-  check_error_and_throw_cuda(error_sync2, "init_lock_arrays_cuda: post init kernel");
+#endif
+  init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>(
+      CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h, CUDA_SPACE_ATOMIC_LOCKS_NODE_h);
+
+  auto error_sync = cudaDeviceSynchronize();
+  check_error_and_throw_cuda(error_sync, "init_lock_arrays_cuda: post init kernel");
 }
 
 template <typename T>

--- a/atomics/src/Lock_Array_HIP.cpp
+++ b/atomics/src/Lock_Array_HIP.cpp
@@ -24,11 +24,11 @@ namespace desul {
 
 namespace {
 
-__global__ void init_lock_arrays_hip_kernel() {
+__global__ void init_lock_arrays_hip_kernel(int32_t* device_locks, int32_t node_locks) {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < HIP_SPACE_ATOMIC_MASK + 1) {
-    Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE[i] = 0;
-    Impl::HIP_SPACE_ATOMIC_LOCKS_NODE[i] = 0;
+    device_locks[i] = 0;
+    node_locks[i] = 0;
   }
 }
 
@@ -68,13 +68,14 @@ void init_lock_arrays_hip() {
   check_error_and_throw_hip(error_malloc2,
                             "init_lock_arrays_hip: hipMallocHost host locks");
 
-  auto error_sync1 = hipDeviceSynchronize();
+#ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
   copy_hip_lock_arrays_to_device();
-  check_error_and_throw_hip(error_sync1, "init_lock_arrays_hip: post malloc");
+#endif
 
-  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
+  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>(
+      HIP_SPACE_ATOMIC_LOCKS_DEVICE_h, HIP_SPACE_ATOMIC_LOCKS_NODE_h);
 
-  auto error_sync2 = hipDeviceSynchronize();
+  auto error_sync = hipDeviceSynchronize();
   check_error_and_throw_hip(error_sync2, "init_lock_arrays_hip: post init");
 }
 


### PR DESCRIPTION
enabling rdc downstream in a non-rdc desul should work as we need to call the ensure_lock_arrays_on_device anyways.

